### PR TITLE
feat: migrate home shell to Tailwind with normalized navigation

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import Flag from 'react-world-flags'
 import { Dispatch, SetStateAction, useContext, useState } from 'react'
 import Header from '../components/Header'
 import Footer from '../components/Footer'
@@ -33,28 +32,28 @@ function HomeContent() {
         />
       )}
       {shouldRenderChild && !showMobileMenu && (
-       <div
-    style={isLanguagesSelected ? mountedStyle : unmountedStyle}
-    className="language-options"
-  >
-    <LanguageOption
-      isLanguagesSelected={isLanguagesSelected}
-      setIsLanguagesSelected={setIsLanguagesSelected}
-    />
-    <span
-      className="language-option"
-      onClick={() => {
-        setLanguage({
-          name: 'en',
-          flag: '840',  // Mantenemos estas propiedades aunque no las usemos
-          height: '15'  // para evitar errores en otras partes de la app
-        })
-        setIsLanguagesSelected(!isLanguagesSelected)
-      }}
-    >
-      EN
-    </span>
-  </div>
+        <div
+          style={isLanguagesSelected ? mountedStyle : unmountedStyle}
+          className="absolute right-8 top-10 z-[999] flex min-w-[70px] max-w-[calc(100vw-64px)] -translate-x-1/2 transform flex-col items-stretch overflow-hidden rounded bg-[#2a2d46] shadow-lg lg:right-8"
+        >
+          <LanguageOption
+            isLanguagesSelected={isLanguagesSelected}
+            setIsLanguagesSelected={setIsLanguagesSelected}
+          />
+          <span
+            className="flex w-full cursor-pointer items-center justify-center rounded px-1 py-2.5 font-poppins-semibold text-base font-semibold transition-all hover:bg-highlighted-background hover:text-uiWhite"
+            onClick={() => {
+              setLanguage({
+                name: 'en',
+                flag: '840',
+                height: '15'
+              })
+              setIsLanguagesSelected(!isLanguagesSelected)
+            }}
+          >
+            EN
+          </span>
+        </div>
       )}
       <Header
         showMobileMenu={showMobileMenu as boolean}
@@ -67,7 +66,6 @@ function HomeContent() {
       <AboutMe />
       <Resume />
       <Badges />
-      <Footer />
       <ContactMe />
     </div>
   )

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -3,10 +3,10 @@ import React from 'react'
 
 const Footer: React.FunctionComponent<object> = () => {
   return (
-    <div className='footer-container'>
-      <div className='footer-parent'>
+    <div className='flex w-full justify-center overflow-hidden'>
+      <div className='flex items-end'>
         <Image
-          className='footer-image'
+          className='h-[130px] max-w-full'
           src='/assets/home/shape.png'
           width={1920}
           height={130}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,10 +1,11 @@
 'use client'
 import Link from 'next/link'
-import { useRouter, usePathname } from 'next/navigation'
+import { usePathname } from 'next/navigation'
 import React, { Dispatch, SetStateAction, useContext } from 'react'
 import { ILanguageContextType } from '../@types/language.types'
 import { LanguageContext } from '../context/LanguageContextProvider'
 import useNavBar from '../hooks/useNavBar'
+
 const Header: React.FunctionComponent<{
   setShowMobileMenu: Dispatch<SetStateAction<boolean>>
   showMobileMenu: boolean
@@ -20,46 +21,58 @@ const Header: React.FunctionComponent<{
   ] = useNavBar()
   const pathname = usePathname()
   const { language } = useContext(LanguageContext) as ILanguageContextType
+  const baseOptionClass =
+    'text-xl font-extrabold transition-colors hover:text-darkOrange lg:text-base'
+  const selectedOptionClass = 'text-darkOrange'
+  const handleSectionClick = (sectionName: string) => {
+    toggleSection(sectionName)
+    if (showMobileMenu) {
+      setShowMobileMenu(false)
+    }
+  }
 
   return (
-    <div className="header-container">
-      <div className="header-parent">
-        <div className="header-hamburger">
+    <header className="flex h-[110px] w-full justify-center text-uiWhite">
+      <div className="relative flex h-full w-full items-center justify-between px-5 md:px-10 lg:w-[70%] lg:justify-around lg:px-0">
+        <button
+          type="button"
+          aria-label="Toggle navigation menu"
+          className="text-uiWhite lg:hidden"
+          onClick={() => {
+            setShowMobileMenu(!showMobileMenu)
+          }}
+        >
           <svg
             aria-hidden="true"
             focusable="false"
             data-prefix="fas"
             data-icon="bars"
-            className="svg-inline--fa fa-bars fa-w-14 header-hamburger-bars"
+            className="mx-2 cursor-pointer text-4xl"
             role="img"
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 448 512"
-            onClick={() => {
-              setShowMobileMenu(!showMobileMenu)
-            }}
           >
             <path
               fill="currentColor"
               d="M16 132h416c8.837 0 16-7.163 16-16V76c0-8.837-7.163-16-16-16H16C7.163 60 0 67.163 0 76v40c0 8.837 7.163 16 16 16zm0 160h416c8.837 0 16-7.163 16-16v-40c0-8.837-7.163-16-16-16H16c-8.837 0-16 7.163-16 16v40c0 8.837 7.163 16 16 16zm0 160h416c8.837 0 16-7.163 16-16v-40c0-8.837-7.163-16-16-16H16c-8.837 0-16 7.163-16 16v40c0 8.837 7.163 16 16 16z"
             ></path>
           </svg>
-        </div>
-        <div className="header-logo">
+        </button>
+
+        <div className="font-poppins-extrabold text-4xl text-uiWhite lg:text-5xl">
           <span>Alejo Torres</span>
         </div>
+
         <div
-          onClick={() => setShowMobileMenu(!showMobileMenu)}
-          className={`header-options ${
-            showMobileMenu ? 'show-hamburger-options' : ''
+          className={`absolute left-0 top-[110px] z-[1000] flex h-[calc(100vh-110px)] w-full flex-col justify-around bg-[#1f2235] px-10 text-base font-semibold transition-transform duration-500 lg:static lg:h-auto lg:w-auto lg:translate-x-0 lg:flex-row lg:items-center lg:gap-12 lg:bg-transparent lg:px-0 ${
+            showMobileMenu ? 'translate-x-0 opacity-100' : '-translate-x-[120%] opacity-0 lg:opacity-100'
           }`}
         >
           <div
-            className={`header-option header-option-seperator  ${
-              isHomeSelected ? 'selected-header-option' : ''
-            }`}
+            className={`${baseOptionClass} ${isHomeSelected ? selectedOptionClass : 'text-uiWhite'}`}
           >
-            <span onClick={() => toggleSection('home')}>
-              <Link href={pathname === '/projects' ? '/' : '#Home'}>
+            <span onClick={() => handleSectionClick('home')}>
+              <Link href={pathname === '/projects' ? '/' : '/#Home'}>
                 {language.name === 'en' ? 'Home' : 'Inicio'}
               </Link>
             </span>
@@ -68,70 +81,57 @@ const Header: React.FunctionComponent<{
             ? (
             <>
               <div
-                className={`header-option header-option-seperator  ${
-                  isAboutMeSelected ? 'selected-header-option' : ''
-                }`}
+                className={`${baseOptionClass} ${isAboutMeSelected ? selectedOptionClass : 'text-uiWhite'}`}
               >
-                <span onClick={() => toggleSection('about-me')}>
-                  <Link href="#AboutMe">
+                <span onClick={() => handleSectionClick('about-me')}>
+                  <Link href="/#AboutMe">
                     {language.name === 'en' ? 'AboutMe' : 'Sobre mi'}
                   </Link>
                 </span>
               </div>
               <div
-                className={`header-option header-option-seperator  ${
-                  isResumeSelected ? 'selected-header-option' : ''
-                }`}
+                className={`${baseOptionClass} ${isResumeSelected ? selectedOptionClass : 'text-uiWhite'}`}
               >
-                <span onClick={() => toggleSection('resume')}>
-                  <Link href="#Resume">
+                <span onClick={() => handleSectionClick('resume')}>
+                  <Link href="/#Resume">
                     {language.name === 'en' ? 'Resume' : 'Trayectoria'}
                   </Link>
                 </span>
               </div>
               <div
-                className={`header-option header-option-seperator  ${
-                  isBadgesSelected ? 'selected-header-option' : ''
-                }`}
+                className={`${baseOptionClass} ${isBadgesSelected ? selectedOptionClass : 'text-uiWhite'}`}
               >
-                <span onClick={() => toggleSection('badges')}>
-                  <Link href="#Badges">
+                <span onClick={() => handleSectionClick('badges')}>
+                  <Link href="/#Badges">
                     {language.name === 'en' ? 'Badges' : 'Premios'}
                   </Link>
                 </span>
               </div>
               <div
-                className={`header-option header-option-seperator ${
-                  isProjectsSelected ? 'selected-header-option' : ''
-                }`}
+                className={`${baseOptionClass} ${isProjectsSelected ? selectedOptionClass : 'text-uiWhite'}`}
               >
-                <span onClick={() => toggleSection('projects')}>
+                <span onClick={() => handleSectionClick('projects')}>
                   <Link href="/projects">
                     {language.name === 'en' ? 'Projects' : 'Proyectos'}
                   </Link>
                 </span>
               </div>
               <div
-                className={`header-option  ${
-                  isContactMeSelected ? 'selected-header-option' : ''
-                }`}
+                className={`${baseOptionClass} ${isContactMeSelected ? selectedOptionClass : 'text-uiWhite'}`}
               >
-                <span onClick={() => toggleSection('contact-me')}>
-                  <Link href="#ContactMe">
+                <span onClick={() => handleSectionClick('contact-me')}>
+                  <Link href="/#ContactMe">
                     {language.name === 'en' ? 'ContactMe' : 'Contactame'}
                   </Link>
                 </span>
               </div>
-               
             </>
               )
             : (
-            <div
-              className={`header-option  ${
-                isProjectsSelected ? 'selected-header-option' : ''
-              }`}
+              <div
+              className={`${baseOptionClass} ${isProjectsSelected ? selectedOptionClass : 'text-uiWhite'}`}
             >
-              <span onClick={() => toggleSection('projects')}>
+              <span onClick={() => handleSectionClick('projects')}>
                 <Link href="/projects">
                   {language.name === 'en' ? 'Projects' : 'Proyectos'}
                 </Link>
@@ -140,7 +140,7 @@ const Header: React.FunctionComponent<{
               )}
         </div>
       </div>
-    </div>
+    </header>
   )
 }
 

--- a/components/Icons.tsx
+++ b/components/Icons.tsx
@@ -13,19 +13,34 @@ const Icons = () => {
   return (
     <>
       <Link href="https://www.facebook.com/alejo.torres.100">
-        <FontAwesomeIcon className="icon" icon={faFacebookSquare} />
+        <FontAwesomeIcon
+          className="cursor-pointer px-2 pr-0 text-uiWhite transition duration-300 ease-out hover:scale-110"
+          icon={faFacebookSquare}
+        />
       </Link>
       <Link href="https://github.com/AlejoTorres2001">
-        <FontAwesomeIcon className="icon" icon={faGithub} />
+        <FontAwesomeIcon
+          className="cursor-pointer px-2 pr-0 text-uiWhite transition duration-300 ease-out hover:scale-110"
+          icon={faGithub}
+        />
       </Link>
       <Link href="https://www.instagram.com/alejootorres/">
-        <FontAwesomeIcon className="icon" icon={faInstagram} />
+        <FontAwesomeIcon
+          className="cursor-pointer px-2 pr-0 text-uiWhite transition duration-300 ease-out hover:scale-110"
+          icon={faInstagram}
+        />
       </Link>
       <Link href="https://www.linkedin.com/in/alejo-torres-919b9921b/">
-        <FontAwesomeIcon className="icon" icon={faLinkedin} />
+        <FontAwesomeIcon
+          className="cursor-pointer px-2 pr-0 text-uiWhite transition duration-300 ease-out hover:scale-110"
+          icon={faLinkedin}
+        />
       </Link>
       <Link href="https://twitter.com/alejotorres2001">
-        <FontAwesomeIcon className="icon" icon={faTwitterSquare} />
+        <FontAwesomeIcon
+          className="cursor-pointer px-2 pr-0 text-uiWhite transition duration-300 ease-out hover:scale-110"
+          icon={faTwitterSquare}
+        />
       </Link>
     </>
   )

--- a/components/LanguageOption.tsx
+++ b/components/LanguageOption.tsx
@@ -13,7 +13,7 @@ const LanguageOption = ({ isLanguagesSelected, setIsLanguagesSelected }: Languag
   
   return (
     <span
-      className="language-option"
+      className="flex w-full cursor-pointer items-center justify-center rounded px-1 py-2.5 font-poppins-semibold text-base font-semibold transition-all hover:bg-highlighted-background hover:text-uiWhite"
       onClick={() => {
         setLanguage({
           name: 'es',

--- a/components/LanguagesContainer.tsx
+++ b/components/LanguagesContainer.tsx
@@ -15,9 +15,9 @@ const LanguagesContainer = ({
   const { language } = useContext(LanguageContext) as ILanguageContextType
   
   return (
-  <div className="language-container">
-    <div 
-      className="language-toggle"
+  <div className="relative z-[1000] mr-8 flex h-[30px] items-center justify-end text-uiWhite lg:mr-20">
+    <div
+      className="flex cursor-pointer items-center justify-center rounded bg-white/10 px-3 py-1.5 font-poppins-semibold text-base font-semibold transition-colors hover:bg-white/20"
       onClick={() => {
         setIsLanguagesSelected(!isLanguagesSelected)
       }}

--- a/components/Profile.tsx
+++ b/components/Profile.tsx
@@ -1,12 +1,11 @@
 'use client'
-import React, { useContext, useState } from 'react'
+import React, { useContext } from 'react'
 import { ILanguageContextType } from '../@types/language.types'
 import { LanguageContext } from '../context/LanguageContextProvider'
 import Icons from './Icons'
-import CvOption from './CvOption'
-import useDelayUnmount from '../hooks/useDelayUnmount'
 import Image from 'next/image'
 import { TypeAnimation } from 'react-type-animation'
+import Link from 'next/link'
 
 const steps = [
   'Fullstack Dev ⚙️',
@@ -22,81 +21,71 @@ const steps = [
   'NestJS 🚀',
   1000
 ]
-const mountedStyle = { animation: 'inAnimation 300ms ease-in' }
-const unmountedStyle = { animation: 'outAnimation 300ms ease-in' }
 const Profile: React.FunctionComponent<object> = () => {
-  const [isCvSelected, setIsCvSelected] = useState(false)
-  const shouldRenderChild = useDelayUnmount(isCvSelected, 300)
   const { language } = useContext(LanguageContext) as ILanguageContextType
+
   return (
     <div
-      className="profile-container"
+      className="flex min-h-fit w-full items-center justify-center bg-[#24263c] px-4 text-center"
       id="Home"
-      onClick={(e) => setIsCvSelected((prevState) => prevState && !prevState)}
     >
-      <div className="profile-parent">
-        <div className="profile-details">
-          <div className="cols">
-            <div className="cols-icons">
+      <div className="mt-10 flex w-full max-w-[1120px] flex-col-reverse items-center text-[#f0f8ff] md:mt-4 md:flex-row md:justify-between">
+        <div>
+          <div>
+            <div>
               <Icons />
             </div>
           </div>
-          <div className="profile-details-name">
-            <span className="primary-text">
+          <div className="font-poppins-semibold text-2xl">
+            <span className="text-uiWhite">
               {''}
               {language.name === 'en'
                 ? "Hello, I'm"
                 : 'Hola, mi nombre es'}{' '}
-              <span className="highlighted-text">Alejo</span>
+              <span className="text-darkOrange">Alejo</span>
             </span>
           </div>
-          <div className="profile-details-role">
-            <span className="primary-text">
+          <div className="my-3.5 flex flex-col">
+            <span className="text-uiWhite">
               {''}
-              <h1>
+              <h1 className="mx-auto flex h-[60px] min-w-[320px] items-center justify-center text-center font-[cursive] text-[28px] md:min-w-[420px] md:text-[40px]">
                 {''}
                 <TypeAnimation sequence={steps} repeat={Infinity} speed={50} />
               </h1>
-              <span className="profile-role-tagline">
+              <span className="mt-1 font-poppins-light text-lg md:text-[19px]">
                 {language.name === 'en'
                   ? 'Building applications with front and back-end technologies.'
                   : 'Creando aplicaciones con tecnologías de FrontEnd y BackEnd.'}
               </span>
             </span>
           </div>
-          <div className="profile-options">
-            <button
-              onClick={(e) => {
-                e.preventDefault()
-                window.location.href =
-                  process.env.NODE_ENV === 'production'
-                    ? 'https://react-ssr-personal-portfolio.vercel.app/#ContactMe'
-                    : 'http://localhost:3000/#ContactMe'
-              }}
-              className="btn primary-btn"
+          <div className="flex items-center justify-center gap-4 md:justify-start">
+            <Link
+              href="/#ContactMe"
+              className="w-[140px] rounded-[50px] border-2 border-[linen] bg-[#1f2235] py-3.5 text-center font-poppins-semibold text-xs text-uiWhite transition hover:border-darkOrange hover:text-[#f0f8ff]"
             >
               {''}
               {language.name === 'en' ? ' Get in Touch' : 'Contactar'}
+            </Link>
+            <button
+              className="w-[140px] rounded-[50px] bg-darkOrange py-3.5 font-poppins-semibold text-xs text-uiWhite transition hover:bg-[#fff8dc] hover:text-[#111]"
+              onClick={(e) => {
+                e.stopPropagation()
+                const cvUrl =
+                  language.name === 'en'
+                    ? 'assets/home/CV-AlejoTorres-EN.pdf'
+                    : 'assets/home/CV-AlejoTorres-ES.pdf'
+                window.open(cvUrl, '_blank')
+              }}
+            >
+              {language.name === 'en' ? 'Get Resume' : 'Descargar CV'}
             </button>
-           <button
-  className="btn highlighted-btn"
-  onClick={(e) => {
-    e.stopPropagation();
-    // Download CV based on current language
-    const cvUrl = language.name === 'en' 
-      ? "assets/home/CV-AlejoTorres-EN.pdf" 
-      : "assets/home/CV-AlejoTorres-ES.pdf";
-    window.open(cvUrl, '_blank');
-  }}
->
-  {language.name === 'en' ? 'Get Resume' : 'Descargar CV'}
-</button>
           </div>
         </div>
-        <div className="profile-picture">
-          <div className="profile-picture-background">
+        <div className="mb-10 mt-4 flex h-[275px] w-[275px] items-center justify-center rounded-full shadow-[0_1px_0_0.5px_var(--white)] sm:h-[320px] sm:w-[320px] md:mb-24 md:h-[380px] md:w-[380px] md:ml-20 lg:ml-1">
+          <div className="h-[93%] w-[93%] rounded-full bg-cover bg-center bg-no-repeat transition duration-1000 ease-out hover:scale-105">
             <Image
-              className="profile-picture-image"
+              className="rounded-full"
               src={'/assets/home/profile-picture.jpg'}
               width={380}
               height={380}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@fortawesome/react-fontawesome": "^0.2.0",
     "autoprefixer": "^10.4.14",
     "eslint-config-next": "^15.3.2",
-    "next": "^15.3.2",
+    "next": "15.3.8",
     "nodemailer": "^6.7.7",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/styles/base/_gobal.css
+++ b/styles/base/_gobal.css
@@ -32,3 +32,25 @@ body ::-webkit-scrollbar-thumb {
 ::-webkit-scrollbar-track {
   background: hsla(0, 0%, 100%, 0.1);
 }
+
+@keyframes inAnimation {
+  0% {
+    transform: translateX(-50%) scaleY(0);
+    opacity: 0;
+  }
+  100% {
+    transform: translateX(-50%) scaleY(1);
+    opacity: 1;
+  }
+}
+
+@keyframes outAnimation {
+  0% {
+    transform: translateX(-50%) scaleY(1);
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(-50%) scaleY(0);
+    opacity: 0;
+  }
+}

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,8 +1,6 @@
 @import './base/_reset.css';
 @import './base/_variables.css';
 @import './base/_gobal.css';
-@import './layout/_header.css';
-@import './layout/_footer.css';
 @import './components/_profile.css';
 @import './components/_aboutMe.css';
 @import './components/_resume.css';


### PR DESCRIPTION
## Summary
- migrate the Home shell components (header, profile, footer, language selector shell) to Tailwind utility classes under Phase 1 high-parity constraints
- remove duplicated footer/divider rendering in home flow
- normalize in-page anchor navigation to route-safe links so behavior is consistent from `/` and `/projects`

## Verification
- `npm run lint`
- `npm run build`
- `npm run build && npm run typecheck`

Closes #16