### PR TITLE
feat: migrate About Resume Projects to Tailwind parity

### DIFF
--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -6,10 +6,11 @@ import Header from '../../components/Header'
 import Project from '../../components/Project'
 import useMobileMenu from '../../hooks/useMobileMenu'
 import projects from '../../projects.json'
-import {Providers} from '../../context/Providers'
- function ProjectsContent() {
+import { Providers } from '../../context/Providers'
+
+function ProjectsContent() {
   const [showMobileMenu, setShowMobileMenu] = useMobileMenu()
-  
+
   return (
     <div className="home-container">
       <Header
@@ -18,15 +19,20 @@ import {Providers} from '../../context/Providers'
           setShowMobileMenu as Dispatch<SetStateAction<boolean>>
         }
       />
-      <main className='container'>
-        <section className="cards">
-          {projects.projectsData.map((project, index) => <Project key={index} {...project}/>)}
+
+      <main className="mx-auto mt-5 grid w-full max-w-[1400px] grid-cols-1 gap-10 px-5 sm:px-8">
+        <section className="grid grid-cols-12 gap-5 sm:gap-10">
+          {projects.projectsData.map((project, index) => (
+            <Project key={index} {...project} />
+          ))}
         </section>
       </main>
+
       <Footer />
     </div>
   )
 }
+
 export default function Projects() {
   return (
     <Providers>

--- a/components/AboutMe.tsx
+++ b/components/AboutMe.tsx
@@ -1,4 +1,5 @@
 'use client'
+import Link from 'next/link'
 import React, { useContext } from 'react'
 import { useInView } from 'react-intersection-observer'
 import { ILanguageContextType } from '../@types/language.types'
@@ -12,10 +13,13 @@ const AboutMe = () => {
   })
 
   return (
-    <div className="about-me-container screen-container" id="AboutMe">
+    <section
+      className="-mt-1 mb-12 flex w-full flex-col items-center justify-center bg-uiWhite"
+      id="AboutMe"
+    >
       <div
         ref={ref}
-        className={`about-me-parent ${inView ? 'appear' : ''} fade-in`}
+        className={`w-[88%] max-w-[1000px] lg:w-[70%] ${inView ? 'appear' : ''} fade-in`}
       >
         <div className="heading-container">
           <div className="screen-heading">
@@ -36,10 +40,10 @@ const AboutMe = () => {
           </div>
         </div>
 
-        <div className="about-me-card">
-          <div className="about-me-profile"></div>
-          <div className="about-me-details">
-            <span className="about-me-description">
+        <div className="mb-8 flex w-full overflow-hidden shadow-[0_0_20px_-2px_#1f2235]">
+          <div className="hidden w-1/2 bg-[url('/assets/home/aboutMe.jpeg')] bg-cover bg-[position:25%] bg-no-repeat lg:block"></div>
+          <div className="w-full p-8 text-justify lg:w-[48%]">
+            <span className="text-[13px] font-[450]">
               {language.name === 'en' ? (
                 <>
                   I’m a <strong>Semi-Senior Software Engineer</strong>, with
@@ -56,8 +60,13 @@ const AboutMe = () => {
                   <strong>Terraform</strong> and DevOps pipelines. I’m
                   passionate about <strong>mentoring</strong> and sharing best
                   practices in Software Development, code quality, Systems
-                  Design. Currently, I’m leading full-stack development at{' '}
-                  <a className="link" href="https://www.empatia.technology">
+                  Design. Currently, I’m leading full-stack development at
+                  <a
+                    className="ml-1 font-bold text-[#1f2235] transition-colors hover:text-darkOrange"
+                    href="https://www.empatia.technology"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
                     EmpatIA
                   </a>
                   . I’m eager to embrace new challenges and continue growing in
@@ -83,8 +92,13 @@ const AboutMe = () => {
                   <strong>Terraform</strong> y pipelines de DevOps. Me apasiona
                   el <strong>mentorado</strong> y la difusión de buenas
                   prácticas en el diseño de APIs, calidad de código y onboarding
-                  de equipos. Actualmente lidero el desarrollo FullStack en{' '}
-                  <a className="link" href="https://www.empatia.technology">
+                  de equipos. Actualmente lidero el desarrollo FullStack en
+                  <a
+                    className="ml-1 font-bold text-[#1f2235] transition-colors hover:text-darkOrange"
+                    href="https://www.empatia.technology"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
                     EmpatIA
                   </a>
                   . Busco nuevos desafíos para seguir aprendiendo y creciendo en
@@ -93,8 +107,8 @@ const AboutMe = () => {
               )}
             </span>
 
-            <div className="about-me-highlights">
-              <div className="highlight-heading">
+            <div className="my-16">
+              <div className="mb-4">
                 <span>
                   {language.name === 'en'
                     ? 'Here are a Few Highlights:'
@@ -102,9 +116,8 @@ const AboutMe = () => {
                 </span>
               </div>
 
-              {/* Common bullets */}
-              <div className="highlight">
-                <div className="highlight-blob"></div>
+              <div className="mb-2.5 flex items-center text-[13px] font-[450]">
+                <div className="mr-2.5 h-2.5 w-2.5 rounded-full bg-darkOrange"></div>
                 <span>
                   {language.name === 'en'
                     ? '4+ years building large-scale Web Systems'
@@ -112,16 +125,16 @@ const AboutMe = () => {
                 </span>
               </div>
 
-              <div className="highlight">
-                <div className="highlight-blob"></div>
+              <div className="mb-2.5 flex items-center text-[13px] font-[450]">
+                <div className="mr-2.5 h-2.5 w-2.5 rounded-full bg-darkOrange"></div>
                 <span>
                   {language.name === 'en'
                     ? 'Expertise in event-driven & microservices architectures'
                     : 'Experto en arquitecturas orientadas a eventos y microservicios'}
                 </span>
               </div>
-              <div className="highlight">
-                <div className="highlight-blob"></div>
+              <div className="mb-2.5 flex items-center text-[13px] font-[450]">
+                <div className="mr-2.5 h-2.5 w-2.5 rounded-full bg-darkOrange"></div>
                 <span>
                   {language.name === 'en'
                     ? 'Implemented CI/CD pipelines with GitHub Actions'
@@ -129,8 +142,8 @@ const AboutMe = () => {
                 </span>
               </div>
 
-              <div className="highlight">
-                <div className="highlight-blob"></div>
+              <div className="mb-2.5 flex items-center text-[13px] font-[450]">
+                <div className="mr-2.5 h-2.5 w-2.5 rounded-full bg-darkOrange"></div>
                 <span>
                   {language.name === 'en'
                     ? 'Generative AI integration and agents orchestration'
@@ -138,8 +151,8 @@ const AboutMe = () => {
                 </span>
               </div>
 
-              <div className="highlight">
-                <div className="highlight-blob"></div>
+              <div className="mb-2.5 flex items-center text-[13px] font-[450]">
+                <div className="mr-2.5 h-2.5 w-2.5 rounded-full bg-darkOrange"></div>
                 <span>
                   {language.name === 'en'
                     ? 'Proficient in SQL & NoSQL database design and optimization'
@@ -147,8 +160,8 @@ const AboutMe = () => {
                 </span>
               </div>
 
-              <div className="highlight">
-                <div className="highlight-blob"></div>
+              <div className="mb-2.5 flex items-center text-[13px] font-[450]">
+                <div className="mr-2.5 h-2.5 w-2.5 rounded-full bg-darkOrange"></div>
                 <span>
                   {language.name === 'en'
                     ? 'Machine learning research experience with Deep Learning'
@@ -156,8 +169,8 @@ const AboutMe = () => {
                 </span>
               </div>
 
-              <div className="highlight">
-                <div className="highlight-blob"></div>
+              <div className="mb-2.5 flex items-center text-[13px] font-[450]">
+                <div className="mr-2.5 h-2.5 w-2.5 rounded-full bg-darkOrange"></div>
                 <span>
                   {language.name === 'en'
                     ? 'Leading FullStack development teams'
@@ -166,26 +179,18 @@ const AboutMe = () => {
               </div>
             </div>
 
-            <div className="about-me-options">
-              <button
-                name="AboutMe"
-                onClick={(e) => {
-                  e.preventDefault()
-                  window.location.href =
-                    process.env.NODE_ENV === 'production'
-                      ? 'https://alejo-torres.com/#ContactMe'
-                      : 'http://localhost:3000/#ContactMe'
-                }}
-                className="btn primary-btn"
+            <div className="flex flex-col gap-4 sm:flex-row">
+              <Link
+                href="/#ContactMe"
+                className="w-full rounded-[50px] border-2 border-[linen] bg-[#1f2235] py-3.5 text-center font-poppins-semibold text-xs text-uiWhite transition hover:border-darkOrange hover:text-[#f0f8ff] sm:w-[160px]"
               >
                 {language.name === 'en' ? 'Contact Me' : 'Contáctame'}
-              </button>
+              </Link>
               <button
                 name="ContactMe"
-                className="btn highlighted-btn"
+                className="w-full rounded-[50px] border-2 border-darkOrange bg-darkOrange py-3.5 font-poppins-semibold text-xs text-uiWhite transition hover:bg-[#fff8dc] hover:text-[#111] sm:w-[160px]"
                 onClick={(e) => {
                   e.preventDefault()
-                  // Download CV based on current language
                   const cvUrl =
                     language.name === 'en'
                       ? 'assets/home/CV-AlejoTorres-EN.pdf'
@@ -199,7 +204,7 @@ const AboutMe = () => {
           </div>
         </div>
       </div>
-    </div>
+    </section>
   )
 }
 

--- a/components/LoadingBar.tsx
+++ b/components/LoadingBar.tsx
@@ -1,12 +1,13 @@
-import React from 'react';
+import React from 'react'
 
 const LoadingBar: React.FC = () => {
   return (
-    <div className="loading-container">
-      <div className="loading-bar">
-        <div className="loading-progress"></div>
+    <div className="flex w-full items-center justify-center py-5">
+      <div className="relative h-1 w-full overflow-hidden rounded bg-black/10">
+        <div className="absolute h-full w-[30%] animate-[loading_1.5s_infinite_ease-in-out] rounded bg-gradient-to-r from-darkOrange to-[#ff5823]"></div>
       </div>
     </div>
-  );
-};
-export default LoadingBar;
+  )
+}
+
+export default LoadingBar

--- a/components/Project.tsx
+++ b/components/Project.tsx
@@ -2,8 +2,9 @@
 import { faGithub } from '@fortawesome/free-brands-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import Image from 'next/image'
-import { useRouter } from 'next/navigation'
+import Link from 'next/link'
 import React from 'react'
+
 type props = {
   name: string
   description: string
@@ -11,31 +12,46 @@ type props = {
   knowMore: string
   date: string
 }
+
 const Project = ({ name, description, image, knowMore, date }: props) => {
-  const router = useRouter()
   return (
-    <div className="card">
-      <div className="card-image-container">
-        <Image src={image} fill sizes='100%' alt='image  description' style={{ objectFit: 'cover' }}  />
+    <article className="relative col-span-12 flex cursor-pointer flex-col bg-[#2c2e44] transition-all duration-300 hover:-translate-y-[7px] md:col-span-6 xl:col-span-4">
+      <div className="relative w-full overflow-hidden pt-[56.25%]">
+        <Image
+          src={image}
+          fill
+          sizes="100%"
+          alt={`Project ${name}`}
+          style={{ objectFit: 'cover' }}
+        />
       </div>
-      <div className="card-content">
-        <p className="card-title">{name}</p>
-        <div className="card-info">
-          <p className="card-description">{description}</p>
+
+      <div className="p-5">
+        <p className="mb-5 text-center font-poppins-semibold text-base font-normal leading-5 text-uiWhite">
+          {name}
+        </p>
+        <div className="flex items-end">
+          <p className="mt-2.5 rounded-[10px] bg-[#1f2235] px-[15px] py-[5px] text-sm font-normal text-uiWhite">
+            {description}
+          </p>
         </div>
       </div>
-      <div className="button-container">
-        <button name='LearnMore'
-          onClick={() => router.push(knowMore)}
-          className="learn-more-button"
+
+      <div className="absolute right-0 m-2.5 flex">
+        <Link
+          href={knowMore}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex h-[30px] w-[30px] items-center justify-center rounded-full border border-darkOrange bg-[#1f2235] text-[#e6e3e3] transition hover:border-[#1f2235] hover:bg-darkOrange hover:text-uiBlack"
         >
           <FontAwesomeIcon icon={faGithub} />
-        </button>
+        </Link>
       </div>
-      <div className="date-container">
-        <p className="date">{date}</p>
+
+      <div className="absolute bottom-0 right-0 mr-2.5 mt-2.5 flex">
+        <p className="mb-auto pt-2.5 text-[11px] font-bold leading-5 text-uiWhite">{date}</p>
       </div>
-    </div>
+    </article>
   )
 }
 

--- a/components/Resume.tsx
+++ b/components/Resume.tsx
@@ -15,11 +15,10 @@ const Proyects = lazy(() => import('./ResumeComponents/Proyects'))
 const Interests = lazy(() => import('./ResumeComponents/Interests'))
 
 const LoadingComponent = () => (
-  <div className="resume-loading">
+  <div className="w-full">
     <LoadingBar />
   </div>
 )
-
 
 const Resume = () => {
   const { language } = useContext(LanguageContext) as ILanguageContextType
@@ -36,9 +35,18 @@ const Resume = () => {
     toggleSection
   ] = useButtons()
 
+  const bulletBaseClass =
+    'my-[15px] flex h-10 cursor-pointer items-center rounded-[20px] bg-[#1f2235] px-2 text-uiWhite transition-all duration-500'
+  const bulletSelectedClass = 'w-full'
+  const bulletCollapsedClass = 'w-4 overflow-hidden'
+
   return (
-    <div ref={ref} className="resume-container screen-container " id="Resume">
-      <div className={`resume-content ${inView ? 'appear' : ''} fade-in`}>
+    <section
+      ref={ref}
+      className="-my-12 flex min-h-fit w-full flex-col items-center justify-center bg-uiWhite"
+      id="Resume"
+    >
+      <div className={`mt-[200px] w-full ${inView ? 'appear' : ''} fade-in`}>
         <div className="heading-container">
           <div className="screen-heading">
             <span>{language.name === 'en' ? 'Resume' : 'Trayectoria'}</span>
@@ -57,51 +65,43 @@ const Resume = () => {
             </div>
           </div>
         </div>
-        <div className="resume-card">
-          <div className="resume-bullets">
-            <div className="bullet-container">
-              <div className="bullet-icons"></div>
-              <div className="bullets">
+
+        <div className="mx-auto mb-20 flex h-auto w-[90%] max-w-[1000px] flex-col items-center lg:h-[360px] lg:flex-row lg:items-stretch">
+          <div className="my-[30px] w-full shadow-[15px_0_9px_-15px_#1f2235] lg:my-0 lg:w-[320px]">
+            <div className="relative flex h-full w-full items-center">
+              <div className="absolute z-[1] h-full w-[34px] bg-[#1f2235]"></div>
+              <div className="relative z-[2] w-[90%] lg:w-[86%]">
                 <div
                   onClick={() => toggleSection('education')}
-                  className={`bullet ${
-                    isSelectedEducation && 'selected-bullet'
+                  className={`${bulletBaseClass} ${
+                    isSelectedEducation ? bulletSelectedClass : bulletCollapsedClass
                   }`}
                 >
                   <Image
-  className="bullet-logo"
-  src="/assets/resume/icons/education.svg"
-  width={16}
-  height={16}
-  alt="Education icon"
-  style={{
-    margin: '0 30px 0 0',
-    maxWidth: '16px',
-    maxHeight: '16px', 
-    display: 'block'   
-  }}
-/>
-                  <span className="bullet-label">
+                    className="mr-[30px] h-4 w-4 shrink-0"
+                    src="/assets/resume/icons/education.svg"
+                    width={16}
+                    height={16}
+                    alt="Education icon"
+                  />
+                  <span className="whitespace-nowrap font-poppins-semibold text-sm">
                     {language.name === 'en' ? 'Education' : 'Educación'}
                   </span>
                 </div>
                 <div
                   onClick={() => toggleSection('work')}
-                  className={`bullet ${isSelectedWork && 'selected-bullet'}`}
+                  className={`${bulletBaseClass} ${
+                    isSelectedWork ? bulletSelectedClass : bulletCollapsedClass
+                  }`}
                 >
-                 <Image
-  className="bullet-logo"
-  src="/assets/resume/icons/work-history.svg"
-  width={16}
-  height={16}
-  alt="Work history icon"
-  style={{
-    margin: '0 30px 0 0',
-    maxWidth: '16px',
-    maxHeight: '16px',
-  }}
-/>
-                  <span className="bullet-label">
+                  <Image
+                    className="mr-[30px] h-4 w-4 shrink-0"
+                    src="/assets/resume/icons/work-history.svg"
+                    width={16}
+                    height={16}
+                    alt="Work history icon"
+                  />
+                  <span className="whitespace-nowrap font-poppins-semibold text-sm">
                     {language.name === 'en'
                       ? 'Work History'
                       : 'Historial de Trabajo'}
@@ -109,22 +109,18 @@ const Resume = () => {
                 </div>
                 <div
                   onClick={() => toggleSection('skills')}
-                  className={`bullet ${isSelectedSkills && 'selected-bullet'}`}
+                  className={`${bulletBaseClass} ${
+                    isSelectedSkills ? bulletSelectedClass : bulletCollapsedClass
+                  }`}
                 >
-                 <Image
-  className="bullet-logo"
-  src="/assets/resume/icons/programming-skills.svg"
-  width={16}
-  height={16}
-  alt="Programming skills icon"
-  style={{
-    margin: '0 30px 0 0',
-    maxWidth: '16px',
-    maxHeight: '16px',
-    display: 'block'
-  }}
-/>
-                  <span className="bullet-label">
+                  <Image
+                    className="mr-[30px] h-4 w-4 shrink-0"
+                    src="/assets/resume/icons/programming-skills.svg"
+                    width={16}
+                    height={16}
+                    alt="Programming skills icon"
+                  />
+                  <span className="whitespace-nowrap font-poppins-semibold text-sm">
                     {language.name === 'en'
                       ? 'Hard Skills'
                       : 'Habilidades Técnicas'}
@@ -132,24 +128,18 @@ const Resume = () => {
                 </div>
                 <div
                   onClick={() => toggleSection('projects')}
-                  className={`bullet ${
-                    isSelectedProyects && 'selected-bullet'
+                  className={`${bulletBaseClass} ${
+                    isSelectedProyects ? bulletSelectedClass : bulletCollapsedClass
                   }`}
                 >
-                 <Image
-  className="bullet-logo"
-  src="/assets/resume/icons/projects.svg"
-  width={16}
-  height={16}
-  alt="Projects icon"
-  style={{
-    margin: '0 30px 0 0',
-    maxWidth: '16px',
-    maxHeight: '16px',
-    display: 'block'
-  }}
-/>
-                  <span className="bullet-label">
+                  <Image
+                    className="mr-[30px] h-4 w-4 shrink-0"
+                    src="/assets/resume/icons/projects.svg"
+                    width={16}
+                    height={16}
+                    alt="Projects icon"
+                  />
+                  <span className="whitespace-nowrap font-poppins-semibold text-sm">
                     {language.name === 'en'
                       ? 'Highlighted Projects'
                       : 'Proyectos Destacados'}
@@ -157,42 +147,37 @@ const Resume = () => {
                 </div>
                 <div
                   onClick={() => toggleSection('interests')}
-                  className={`bullet ${
-                    isSelectedInterests && 'selected-bullet'
+                  className={`${bulletBaseClass} ${
+                    isSelectedInterests ? bulletSelectedClass : bulletCollapsedClass
                   }`}
                 >
-                 <Image
-  className="bullet-logo"
-  src="/assets/resume/icons/interests.svg"
-  width={16}
-  height={16}
-  alt="Interests icon"
-  style={{
-    margin: '0 30px 0 0',
-    maxWidth: '16px',
-    maxHeight: '16px',
-    display: 'block'
-  }}
-/>
-                  <span className="bullet-label">
+                  <Image
+                    className="mr-[30px] h-4 w-4 shrink-0"
+                    src="/assets/resume/icons/interests.svg"
+                    width={16}
+                    height={16}
+                    alt="Interests icon"
+                  />
+                  <span className="whitespace-nowrap font-poppins-semibold text-sm">
                     {language.name === 'en' ? 'Interests' : 'Intereses'}
                   </span>
                 </div>
               </div>
             </div>
           </div>
-          <div className="resume-bullet-details">
-        <Suspense fallback={<LoadingComponent />}>
-          {isSelectedEducation && <Education />}
-          {isSelectedWork && <Work />}
-          {isSelectedSkills && <Skills />}
-          {isSelectedProyects && <Proyects />}
-          {isSelectedInterests && <Interests />}
-        </Suspense>
-      </div>
+
+          <div className="h-[360px] w-full overflow-y-auto pl-0 lg:w-[600px] lg:pl-20">
+            <Suspense fallback={<LoadingComponent />}>
+              {isSelectedEducation && <Education />}
+              {isSelectedWork && <Work />}
+              {isSelectedSkills && <Skills />}
+              {isSelectedProyects && <Proyects />}
+              {isSelectedInterests && <Interests />}
+            </Suspense>
+          </div>
         </div>
       </div>
-    </div>
+    </section>
   )
 }
 

--- a/components/ResumeComponents/Education.tsx
+++ b/components/ResumeComponents/Education.tsx
@@ -7,30 +7,30 @@ const Education: React.FunctionComponent<object> = () => {
   const { language } = useContext(LanguageContext) as ILanguageContextType
 
   return (
-    <div className="resume-details-carousal">
-      <div className="resume-screen-container">
-        <div className="resume-heading">
-          <div className="resume-main-heading">
-            <div className="heading-bullet"></div>
-            <span>
+    <div className="animate-[fadeInAnimation_2s]">
+      <div className="mb-8 flex w-full flex-col">
+        <div className="mb-[30px] flex w-full flex-col">
+          <div className="relative mb-3.5 flex justify-between">
+            <div className="absolute -left-[30px] top-[5px] h-[15px] w-[15px] rounded-full bg-darkOrange max-lg:hidden"></div>
+            <span className="mb-[15px] font-poppins-semibold text-xl text-darkOrange">
               {language.name === 'en'
                 ? 'AI Engineer – SMILE Scholarship'
                 : 'Ingeniería en IA – Beca SMILE'}
             </span>
-            <div className="heading-date">
+            <div className="flex h-[27px] w-[120px] items-center justify-center rounded-[14px] bg-darkOrange px-[14px] py-1 text-sm text-uiWhite">
               {language.name === 'en'
                 ? 'Feb – Jul 2023'
                 : 'Feb – Jul 2023'}
             </div>
           </div>
-          <div className="resume-sub-heading">
+          <div className="mb-[15px] mt-[-5px] ml-[10px] text-[15px] text-uiBlack">
             <span>
               {language.name === 'en'
                 ? 'Polytechnic University of Madrid (UPM), Madrid, Spain'
                 : 'Universidad Politécnica de Madrid (UPM), Madrid, España'}
             </span>
           </div>
-          <div className="resume-heading-description">
+          <div className="mb-[15px] ml-[15px] mt-[10px] text-justify text-[13px] leading-normal">
             <span>
               {language.name === 'en'
                 ? 'Cum laude in Microservices Architectures, Intelligent Systems, Machine Learning II'
@@ -39,27 +39,26 @@ const Education: React.FunctionComponent<object> = () => {
           </div>
         </div>
 
-        {/* Catholic University of Salta */}
-        <div className="resume-heading">
-          <div className="resume-main-heading">
-            <div className="heading-bullet"></div>
-            <span>
+        <div className="mb-[30px] flex w-full flex-col">
+          <div className="relative mb-3.5 flex justify-between">
+            <div className="absolute -left-[30px] top-[5px] h-[15px] w-[15px] rounded-full bg-darkOrange max-lg:hidden"></div>
+            <span className="mb-[15px] font-poppins-semibold text-xl text-darkOrange">
               {language.name === 'en'
                 ? 'Computer Science Engineer, Cum Laude'
                 : 'Ingeniero en Informática, Cum Laude'}
             </span>
-            <div className="heading-date">
+            <div className="flex h-[27px] w-[120px] items-center justify-center rounded-[14px] bg-darkOrange px-[14px] py-1 text-sm text-uiWhite">
               {language.name === 'en' ? 'Dec 2024' : 'Dic 2024'}
             </div>
           </div>
-          <div className="resume-sub-heading">
+          <div className="mb-[15px] mt-[-5px] ml-[10px] text-[15px] text-uiBlack">
             <span>
               {language.name === 'en'
                 ? 'Catholic University of Salta, Salta, Argentina'
                 : 'Universidad Católica de Salta, Salta, Argentina'}
             </span>
           </div>
-          <div className="resume-heading-description">
+          <div className="mb-[15px] ml-[15px] mt-[10px] text-justify text-[13px] leading-normal">
             <span>
               {language.name === 'en'
                 ? 'Academic Excellence Award – 2023'

--- a/components/ResumeComponents/Interests.tsx
+++ b/components/ResumeComponents/Interests.tsx
@@ -7,22 +7,22 @@ const Interests: React.FunctionComponent<object> = () => {
   const { language } = useContext(LanguageContext) as ILanguageContextType
 
   return (
-    <div className="resume-details-carousal">
-      <div className="resume-screen-container">
-        <div className="resume-heading">
-          <div className="resume-main-heading">
-            <div className="heading-bullet"></div>
-            <span>
+    <div className="animate-[fadeInAnimation_2s]">
+      <div className="mb-8 flex w-full flex-col">
+        <div className="mb-[30px] flex w-full flex-col">
+          <div className="relative mb-3.5 flex justify-between">
+            <div className="absolute -left-[30px] top-[5px] h-[15px] w-[15px] rounded-full bg-darkOrange max-lg:hidden"></div>
+            <span className="mb-[15px] font-poppins-semibold text-xl text-darkOrange">
               {language.name === 'en'
                 ? 'Teaching'
                 : 'Transmitir mis Conocimientos'}
             </span>
             <div></div>
           </div>
-          <div className="resume-sub-heading">
+          <div className="mb-[15px] mt-[-5px] ml-[10px] text-[15px] text-uiBlack">
             <span></span>
           </div>
-          <div className="resume-heading-description">
+          <div className="mb-[15px] ml-[15px] mt-[10px] text-justify text-[13px] leading-normal">
             <span>
               {language.name === 'en'
                 ? 'Apart from being a tech enthusiast, I also love to share my knowledge to other, helping them to achieve their goals and improve their skills.'
@@ -30,18 +30,19 @@ const Interests: React.FunctionComponent<object> = () => {
             </span>
           </div>
         </div>
-        <div className="resume-heading">
-          <div className="resume-main-heading">
-            <div className="heading-bullet"></div>
-            <span>
+
+        <div className="mb-[30px] flex w-full flex-col">
+          <div className="relative mb-3.5 flex justify-between">
+            <div className="absolute -left-[30px] top-[5px] h-[15px] w-[15px] rounded-full bg-darkOrange max-lg:hidden"></div>
+            <span className="mb-[15px] font-poppins-semibold text-xl text-darkOrange">
               {language.name === 'en' ? 'Collaboration' : 'Colaborar'}
             </span>
             <div></div>
           </div>
-          <div className="resume-sub-heading">
+          <div className="mb-[15px] mt-[-5px] ml-[10px] text-[15px] text-uiBlack">
             <span></span>
           </div>
-          <div className="resume-heading-description">
+          <div className="mb-[15px] ml-[15px] mt-[10px] text-justify text-[13px] leading-normal">
             <span>
               {language.name === 'en'
                 ? "I'm looking to collaborate with other Devs in meaningful projects that have a positive impact in the Tech World"
@@ -49,16 +50,17 @@ const Interests: React.FunctionComponent<object> = () => {
             </span>
           </div>
         </div>
-        <div className="resume-heading">
-          <div className="resume-main-heading">
-            <div className="heading-bullet"></div>
-            <span>{language.name === 'en' ? 'Music' : 'Musica'}</span>
+
+        <div className="mb-[30px] flex w-full flex-col">
+          <div className="relative mb-3.5 flex justify-between">
+            <div className="absolute -left-[30px] top-[5px] h-[15px] w-[15px] rounded-full bg-darkOrange max-lg:hidden"></div>
+            <span className="mb-[15px] font-poppins-semibold text-xl text-darkOrange">{language.name === 'en' ? 'Music' : 'Musica'}</span>
             <div></div>
           </div>
-          <div className="resume-sub-heading">
+          <div className="mb-[15px] mt-[-5px] ml-[10px] text-[15px] text-uiBlack">
             <span></span>
           </div>
-          <div className="resume-heading-description">
+          <div className="mb-[15px] ml-[15px] mt-[10px] text-justify text-[13px] leading-normal">
             <span>
               {language.name === 'en'
                 ? 'occasionally play the drums'

--- a/components/ResumeComponents/Proyects.tsx
+++ b/components/ResumeComponents/Proyects.tsx
@@ -5,31 +5,34 @@ import Link from 'next/link'
 import React, { useContext } from 'react'
 import { ILanguageContextType } from '../../@types/language.types'
 import { LanguageContext } from '../../context/LanguageContextProvider'
-import { useRouter, usePathname } from 'next/navigation'
+import { useRouter } from 'next/navigation'
+
 const Proyects: React.FunctionComponent<object> = () => {
   const router = useRouter()
   const { language } = useContext(LanguageContext) as ILanguageContextType
 
   return (
-    <div className="resume-details-carousal">
-      <div className="resume-screen-container">
-        <div className="resume-heading">
-          <div className="resume-main-heading">
-            <div className="heading-bullet"></div>
-            <span className="title">
+    <div className="animate-[fadeInAnimation_2s]">
+      <div className="mb-8 flex w-full flex-col">
+        <div className="mb-[30px] flex w-full flex-col">
+          <div className="relative mb-3.5 flex justify-between">
+            <div className="absolute -left-[30px] top-[5px] h-[15px] w-[15px] rounded-full bg-darkOrange max-lg:hidden"></div>
+            <span className="mb-[15px] font-poppins-semibold text-xl text-darkOrange transition-colors hover:text-uiBlack">
               <Link
                 href={
                   'https://github.com/AlejoTorres2001/React-SSR-Personal-Portfolio'
                 }
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 {language.name === 'en'
                   ? ' Personal Portfolio Website'
                   : 'Sitio Web Personal'}
               </Link>
             </span>
-            <div className="heading-date">2022-2022</div>
+            <div className="flex h-[27px] w-[120px] items-center justify-center rounded-[14px] bg-darkOrange px-[14px] py-1 text-sm text-uiWhite">2022-2022</div>
           </div>
-          <div className="resume-sub-heading">
+          <div className="mb-[15px] mt-[-5px] ml-[10px] text-[15px] text-uiBlack">
             <span>
               {language.name === 'en'
                 ? 'Technologies Used:'
@@ -37,7 +40,7 @@ const Proyects: React.FunctionComponent<object> = () => {
               Nextjs,ReactJs,Typescript,vanilla CSS
             </span>
           </div>
-          <div className="resume-heading-description">
+          <div className="mb-[15px] ml-[15px] mt-[10px] text-justify text-[13px] leading-normal">
             <span>
               {language.name === 'en'
                 ? 'A personal web portfolio to showcase all my details and projectsat one place. Using SSR for faster load time'
@@ -45,15 +48,16 @@ const Proyects: React.FunctionComponent<object> = () => {
             </span>
           </div>
         </div>
-        <div className="resume-heading">
-          <div className="resume-main-heading">
-            <div className="heading-bullet"></div>
+
+        <div className="mb-[30px] flex w-full flex-col">
+          <div className="relative mb-3.5 flex justify-between">
+            <div className="absolute -left-[30px] top-[5px] h-[15px] w-[15px] rounded-full bg-darkOrange max-lg:hidden"></div>
             <Link href={'https://github.com/AlejoTorres2001/code-playground'}>
-              <span className="title">Codify</span>
+              <span className="mb-[15px] font-poppins-semibold text-xl text-darkOrange transition-colors hover:text-uiBlack">Codify</span>
             </Link>
-            <div className="heading-date">2022-2022</div>
+            <div className="flex h-[27px] w-[120px] items-center justify-center rounded-[14px] bg-darkOrange px-[14px] py-1 text-sm text-uiWhite">2022-2022</div>
           </div>
-          <div className="resume-sub-heading">
+          <div className="mb-[15px] mt-[-5px] ml-[10px] text-[15px] text-uiBlack">
             <span>
               {language.name === 'en'
                 ? 'Technologies Used:'
@@ -61,7 +65,7 @@ const Proyects: React.FunctionComponent<object> = () => {
               Vite,ReactJs,TailwindCSS,Redux
             </span>
           </div>
-          <div className="resume-heading-description">
+          <div className="mb-[15px] ml-[15px] mt-[10px] text-justify text-[13px] leading-normal">
             <span>
               {language.name === 'en'
                 ? ' An easy to use, real time HTML + CSS + JS code playground,inspired by liveweave. Codify is a live editor for HTML,CSS AND JS allowing you to edit your code in real-time, and see your results instantly, without reloading the page.'
@@ -69,15 +73,16 @@ const Proyects: React.FunctionComponent<object> = () => {
             </span>
           </div>
         </div>
-        <div className="resume-heading">
-          <div className="resume-main-heading">
-            <div className="heading-bullet"></div>
+
+        <div className="mb-[30px] flex w-full flex-col">
+          <div className="relative mb-3.5 flex justify-between">
+            <div className="absolute -left-[30px] top-[5px] h-[15px] w-[15px] rounded-full bg-darkOrange max-lg:hidden"></div>
             <Link href={'https://github.com/AlejoTorres2001/chat.io'}>
-              <span className="title">Chat.io</span>
+              <span className="mb-[15px] font-poppins-semibold text-xl text-darkOrange transition-colors hover:text-uiBlack">Chat.io</span>
             </Link>
-            <div className="heading-date">2022-2022</div>
+            <div className="flex h-[27px] w-[120px] items-center justify-center rounded-[14px] bg-darkOrange px-[14px] py-1 text-sm text-uiWhite">2022-2022</div>
           </div>
-          <div className="resume-sub-heading">
+          <div className="mb-[15px] mt-[-5px] ml-[10px] text-[15px] text-uiBlack">
             <span>
               {language.name === 'en'
                 ? 'Technologies Used: '
@@ -85,7 +90,7 @@ const Proyects: React.FunctionComponent<object> = () => {
               Express,MondoDB,SocketIO,Vite,React,TailwindCSS
             </span>
           </div>
-          <div className="resume-heading-description">
+          <div className="mb-[15px] ml-[15px] mt-[10px] text-justify text-[13px] leading-normal">
             <span>
               {language.name === 'en'
                 ? 'A Fullstack webSocket-based WhatsApp clone. The Core concept here revolves around WebSocket, instead of the classic server polling architecture, using an event-based communication allows for (almost) real-time communication between the server and our clients, who will listen and react to the changes. The frontEnd client is inspired on WhatsApp web'
@@ -93,21 +98,24 @@ const Proyects: React.FunctionComponent<object> = () => {
             </span>
           </div>
         </div>
-        <div className="resume-heading">
-          <div className="resume-main-heading">
-            <div className="heading-bullet"></div>
+
+        <div className="mb-[30px] flex w-full flex-col">
+          <div className="relative mb-3.5 flex justify-between">
+            <div className="absolute -left-[30px] top-[5px] h-[15px] w-[15px] rounded-full bg-darkOrange max-lg:hidden"></div>
             <Link
               href={
                 'https://github.com/CoolRobotsAndStuff/machine-learning-for-maze-exploration'
               }
+              target="_blank"
+              rel="noopener noreferrer"
             >
-              <span className="title">
+              <span className="mb-[15px] font-poppins-semibold text-xl text-darkOrange transition-colors hover:text-uiBlack">
                 Maze Exploration Deep-Q Learning AI Model
               </span>
             </Link>
-            <div className="heading-date">2022-2022</div>
+            <div className="flex h-[27px] w-[120px] items-center justify-center rounded-[14px] bg-darkOrange px-[14px] py-1 text-sm text-uiWhite">2022-2022</div>
           </div>
-          <div className="resume-sub-heading">
+          <div className="mb-[15px] mt-[-5px] ml-[10px] text-[15px] text-uiBlack">
             <span>
               {' '}
               {language.name === 'en'
@@ -116,7 +124,7 @@ const Proyects: React.FunctionComponent<object> = () => {
               Python,Keras,MLFlow
             </span>
           </div>
-          <div className="resume-heading-description">
+          <div className="mb-[15px] ml-[15px] mt-[10px] text-justify text-[13px] leading-normal">
             <span>
               {language.name === 'en'
                 ? 'Part of my internship at IITA. A simplified test environment for Webots simulator,a Deep-  Q learning Model and a Random Map Generator for it to be trained on, registring all progress in a MLFlow Server hosted on Google Cloud Computing'
@@ -124,10 +132,11 @@ const Proyects: React.FunctionComponent<object> = () => {
             </span>
           </div>
         </div>
-        <div className="projects-btn-container">
+
+        <div className="flex justify-end">
           <button
             onClick={() => router.push('/projects')}
-            className="projects-btn"
+            className="mt-4 w-40 rounded-[19px] border-2 border-darkOrange bg-[#1f2235] p-1 text-[11px] text-[#e6e3e3] transition hover:border-[#1f2235] hover:bg-darkOrange hover:text-uiBlack"
           >
             {language.name === 'en' ? 'More Projects' : 'Mas Proyectos'}{' '}
             <FontAwesomeIcon icon={faGithub} />

--- a/components/ResumeComponents/Skills.tsx
+++ b/components/ResumeComponents/Skills.tsx
@@ -1,82 +1,83 @@
 import React from 'react'
 
 const Skills: React.FunctionComponent<object> = () => {
+  const skillRowClass = 'relative flex w-full flex-col md:w-[48%]'
+  const headingDotClass =
+    'absolute -left-[30px] top-[5px] h-[15px] w-[15px] rounded-full bg-darkOrange max-lg:hidden'
+
   return (
-    <div className="resume-details-carousal">
-      <div className="resume-screen-container programming-skills-container">
-        {/* Backend & Infrastructure */}
-        <div className="skill-parent">
-          <div className="heading-bullet"></div>
-          <span>Node.js / TypeScript</span>
-          <div className="skill-percentage">
-            <div className="active-percentage-bar" style={{ width: '95%' }}></div>
+    <div className="animate-[fadeInAnimation_2s]">
+      <div className="flex w-full flex-row flex-wrap items-center justify-between gap-y-2">
+        <div className={skillRowClass}>
+          <div className={headingDotClass}></div>
+          <span className="font-poppins-bold text-base text-darkOrange">Node.js / TypeScript</span>
+          <div className="mb-6 mt-1.5 h-[15px] w-[70%] bg-darkOrange">
+            <div className="h-[15px] bg-[#1f2235] transition-all duration-700" style={{ width: '95%' }}></div>
           </div>
         </div>
-        <div className="skill-parent">
-          <div className="heading-bullet"></div>
-          <span>NestJS / Express</span>
-          <div className="skill-percentage">
-            <div className="active-percentage-bar" style={{ width: '92%' }}></div>
+        <div className={skillRowClass}>
+          <div className={headingDotClass}></div>
+          <span className="font-poppins-bold text-base text-darkOrange">NestJS / Express</span>
+          <div className="mb-6 mt-1.5 h-[15px] w-[70%] bg-darkOrange">
+            <div className="h-[15px] bg-[#1f2235] transition-all duration-700" style={{ width: '92%' }}></div>
           </div>
         </div>
-        <div className="skill-parent">
-          <div className="heading-bullet"></div>
-          <span>Python (Pandas, TensorFlow, PyTorch)</span>
-          <div className="skill-percentage">
-            <div className="active-percentage-bar" style={{ width: '85%' }}></div>
+        <div className={skillRowClass}>
+          <div className={headingDotClass}></div>
+          <span className="font-poppins-bold text-base text-darkOrange">Python (Pandas, TensorFlow, PyTorch)</span>
+          <div className="mb-6 mt-1.5 h-[15px] w-[70%] bg-darkOrange">
+            <div className="h-[15px] bg-[#1f2235] transition-all duration-700" style={{ width: '85%' }}></div>
           </div>
         </div>
-        <div className="skill-parent">
-          <div className="heading-bullet"></div>
-          <span>SQL / Database Design</span>
-          <div className="skill-percentage">
-            <div className="active-percentage-bar" style={{ width: '85%' }}></div>
-          </div>
-        </div>
-
-        {/* Frontend */}
-        <div className="skill-parent">
-          <div className="heading-bullet"></div>
-          <span>React.js / Next.js</span>
-          <div className="skill-percentage">
-            <div className="active-percentage-bar" style={{ width: '90%' }}></div>
-          </div>
-        </div>
-        <div className="skill-parent">
-          <div className="heading-bullet"></div>
-          <span>HTML5 / CSS3</span>
-          <div className="skill-percentage">
-            <div className="active-percentage-bar" style={{ width: '92%' }}></div>
-          </div>
-        </div>
-        <div className="skill-parent">
-          <div className="heading-bullet"></div>
-          <span>Terraform / IaC</span>
-          <div className="skill-percentage">
-            <div className="active-percentage-bar" style={{ width: '80%' }}></div>
-          </div>
-        </div>
-        <div className="skill-parent">
-          <div className="heading-bullet"></div>
-          <span>Azure / GCP</span>
-          <div className="skill-percentage">
-            <div className="active-percentage-bar" style={{ width: '78%' }}></div>
+        <div className={skillRowClass}>
+          <div className={headingDotClass}></div>
+          <span className="font-poppins-bold text-base text-darkOrange">SQL / Database Design</span>
+          <div className="mb-6 mt-1.5 h-[15px] w-[70%] bg-darkOrange">
+            <div className="h-[15px] bg-[#1f2235] transition-all duration-700" style={{ width: '85%' }}></div>
           </div>
         </div>
 
-        {/* Tools & Methodologies */}
-        <div className="skill-parent">
-          <div className="heading-bullet"></div>
-          <span>Git / CI-CD / DevOps Pipelines</span>
-          <div className="skill-percentage">
-            <div className="active-percentage-bar" style={{ width: '90%' }}></div>
+        <div className={skillRowClass}>
+          <div className={headingDotClass}></div>
+          <span className="font-poppins-bold text-base text-darkOrange">React.js / Next.js</span>
+          <div className="mb-6 mt-1.5 h-[15px] w-[70%] bg-darkOrange">
+            <div className="h-[15px] bg-[#1f2235] transition-all duration-700" style={{ width: '90%' }}></div>
           </div>
         </div>
-        <div className="skill-parent">
-          <div className="heading-bullet"></div>
-          <span>Distributed Systems (Bull, n8n)</span>
-          <div className="skill-percentage">
-            <div className="active-percentage-bar" style={{ width: '85%' }}></div>
+        <div className={skillRowClass}>
+          <div className={headingDotClass}></div>
+          <span className="font-poppins-bold text-base text-darkOrange">HTML5 / CSS3</span>
+          <div className="mb-6 mt-1.5 h-[15px] w-[70%] bg-darkOrange">
+            <div className="h-[15px] bg-[#1f2235] transition-all duration-700" style={{ width: '92%' }}></div>
+          </div>
+        </div>
+        <div className={skillRowClass}>
+          <div className={headingDotClass}></div>
+          <span className="font-poppins-bold text-base text-darkOrange">Terraform / IaC</span>
+          <div className="mb-6 mt-1.5 h-[15px] w-[70%] bg-darkOrange">
+            <div className="h-[15px] bg-[#1f2235] transition-all duration-700" style={{ width: '80%' }}></div>
+          </div>
+        </div>
+        <div className={skillRowClass}>
+          <div className={headingDotClass}></div>
+          <span className="font-poppins-bold text-base text-darkOrange">Azure / GCP</span>
+          <div className="mb-6 mt-1.5 h-[15px] w-[70%] bg-darkOrange">
+            <div className="h-[15px] bg-[#1f2235] transition-all duration-700" style={{ width: '78%' }}></div>
+          </div>
+        </div>
+
+        <div className={skillRowClass}>
+          <div className={headingDotClass}></div>
+          <span className="font-poppins-bold text-base text-darkOrange">Git / CI-CD / DevOps Pipelines</span>
+          <div className="mb-6 mt-1.5 h-[15px] w-[70%] bg-darkOrange">
+            <div className="h-[15px] bg-[#1f2235] transition-all duration-700" style={{ width: '90%' }}></div>
+          </div>
+        </div>
+        <div className={skillRowClass}>
+          <div className={headingDotClass}></div>
+          <span className="font-poppins-bold text-base text-darkOrange">Distributed Systems (Bull, n8n)</span>
+          <div className="mb-6 mt-1.5 h-[15px] w-[70%] bg-darkOrange">
+            <div className="h-[15px] bg-[#1f2235] transition-all duration-700" style={{ width: '85%' }}></div>
           </div>
         </div>
       </div>

--- a/components/ResumeComponents/Work.tsx
+++ b/components/ResumeComponents/Work.tsx
@@ -9,25 +9,25 @@ const Work: React.FunctionComponent<object> = () => {
   const t = (en: string, es: string) => language.name === 'en' ? en : es
 
   return (
-    <div className="resume-details-carousal">
-      <div className="experience-container">
+    <div className="animate-[fadeInAnimation_2s]">
+      <div>
 
         {/* EmpatIA */}
-        <div className="resume-heading">
-          <div className="resume-main-heading">
-            <div className="heading-bullet" />
-            <span>{t('FullStack Tech Leader', 'Líder Técnico FullStack')}</span>
-            <div className="heading-date">{t('Aug 2024', 'Ago 2024')}</div>
+        <div className="mb-[30px] flex w-full flex-col">
+          <div className="relative mb-3.5 flex justify-between">
+            <div className="absolute -left-[30px] top-[5px] h-[15px] w-[15px] rounded-full bg-darkOrange max-lg:hidden" />
+            <span className="mb-[15px] font-poppins-semibold text-xl text-darkOrange">{t('FullStack Tech Leader', 'Líder Técnico FullStack')}</span>
+            <div className="flex h-[27px] w-[120px] items-center justify-center rounded-[14px] bg-darkOrange px-[14px] py-1 text-sm text-uiWhite">{t('Aug 2024', 'Ago 2024')}</div>
           </div>
-          <div className="resume-sub-heading">
+          <div className="mb-[15px] mt-[-5px] ml-[10px] text-[15px] text-uiBlack">
             <span>EmpatIA, Madrid, {t('Spain', 'España')}</span>
           </div>
-          <div className="resume-heading-description">
+          <div className="mb-[15px] ml-[15px] mt-[10px] text-justify text-[13px] leading-normal">
             <span>{t('Leading cloud-native full-stack development on Azure.', 'Liderando desarrollo full-stack nativo en la nube sobre Azure.')}</span>
           </div>
         </div>
-        <div className="experience-description">
-          <span className="resume-description-text">
+        <div className="mb-2.5 mt-2.5 max-w-full text-justify">
+          <span className="text-xs">
             - {t(
               'Built scalable applications with React.js and NestJS over Azure App Services and AKS.',
               'Desarrollo de aplicaciones escalables con React.js y NestJS sobre Azure App Services y AKS.'
@@ -48,25 +48,25 @@ const Work: React.FunctionComponent<object> = () => {
         </div>
 
         {/* Altostratus */}
-        <div className="resume-heading">
-          <div className="resume-main-heading">
-            <div className="heading-bullet" />
-            <span>{t('FullStack Developer', 'Desarrollador FullStack')}</span>
-            <div className="heading-date">{t('Apr – Dec 2023', 'Abr – Dic 2023')}</div>
+        <div className="mb-[30px] flex w-full flex-col">
+          <div className="relative mb-3.5 flex justify-between">
+            <div className="absolute -left-[30px] top-[5px] h-[15px] w-[15px] rounded-full bg-darkOrange max-lg:hidden" />
+            <span className="mb-[15px] font-poppins-semibold text-xl text-darkOrange">{t('FullStack Developer', 'Desarrollador FullStack')}</span>
+            <div className="flex h-[27px] w-[120px] items-center justify-center rounded-[14px] bg-darkOrange px-[14px] py-1 text-sm text-uiWhite">{t('Apr – Dec 2023', 'Abr – Dic 2023')}</div>
           </div>
-          <div className="resume-sub-heading">
+          <div className="mb-[15px] mt-[-5px] ml-[10px] text-[15px] text-uiBlack">
             <span>
-              <a className="link" href="https://www.altostratus.es/">
+              <a className="font-bold text-[#1f2235] transition-colors hover:text-darkOrange" href="https://www.altostratus.es/" target="_blank" rel="noopener noreferrer">
                 Altostratus Cloud Consulting, Madrid, {t('Spain', 'España')}
               </a>
             </span>
           </div>
-          <div className="resume-heading-description">
+          <div className="mb-[15px] ml-[15px] mt-[10px] text-justify text-[13px] leading-normal">
             <span>{t('Cloud-native architecture on GCP and frontend systems.', 'Arquitectura cloud en GCP y desarrollo frontend.')}</span>
           </div>
         </div>
-        <div className="experience-description">
-          <span className="resume-description-text">
+        <div className="mb-2.5 mt-2.5 max-w-full text-justify">
+          <span className="text-xs">
             - {t(
               'Designed distributed data-processing pipelines in Python, improving efficiency by 15%.',
               'Diseño de pipelines de procesamiento distribuido en Python, mejorando eficiencia en un 15%.'
@@ -87,25 +87,25 @@ const Work: React.FunctionComponent<object> = () => {
         </div>
 
         {/* Silentium Apps */}
-        <div className="resume-heading">
-          <div className="resume-main-heading">
-            <div className="heading-bullet" />
-            <span>{t('Trainee Developer', 'Desarrollador en Formación')}</span>
-            <div className="heading-date">{t('Aug – Dec 2022', 'Ago – Dic 2022')}</div>
+        <div className="mb-[30px] flex w-full flex-col">
+          <div className="relative mb-3.5 flex justify-between">
+            <div className="absolute -left-[30px] top-[5px] h-[15px] w-[15px] rounded-full bg-darkOrange max-lg:hidden" />
+            <span className="mb-[15px] font-poppins-semibold text-xl text-darkOrange">{t('Trainee Developer', 'Desarrollador en Formación')}</span>
+            <div className="flex h-[27px] w-[120px] items-center justify-center rounded-[14px] bg-darkOrange px-[14px] py-1 text-sm text-uiWhite">{t('Aug – Dec 2022', 'Ago – Dic 2022')}</div>
           </div>
-          <div className="resume-sub-heading">
+          <div className="mb-[15px] mt-[-5px] ml-[10px] text-[15px] text-uiBlack">
             <span>
-              <a className="link" href="https://silentiumapps.com/es/">
+              <a className="font-bold text-[#1f2235] transition-colors hover:text-darkOrange" href="https://silentiumapps.com/es/" target="_blank" rel="noopener noreferrer">
                 Silentium Apps, Salta, Argentina
               </a>
             </span>
           </div>
-          <div className="resume-heading-description">
+          <div className="mb-[15px] ml-[15px] mt-[10px] text-justify text-[13px] leading-normal">
             <span>{t('Enhanced backend performance and research in frameworks.', 'Mejora de rendimiento y exploración de frameworks.')}</span>
           </div>
         </div>
-        <div className="experience-description">
-          <span className="resume-description-text">
+        <div className="mb-2.5 mt-2.5 max-w-full text-justify">
+          <span className="text-xs">
             - {t(
               'Improved backend performance by 20% via refactoring in NestJS and .NET.',
               'Mejora del backend en un 20% mediante refactorización en NestJS y .NET.'
@@ -122,24 +122,24 @@ const Work: React.FunctionComponent<object> = () => {
         </div>
 
         {/* IITA */}
-        <div className="resume-heading">
-          <div className="resume-main-heading">
-            <div className="heading-bullet" />
-            <span>{t('Machine Learning Researcher', 'Investigador en Machine Learning')}</span>
-            <div className="heading-date">{t('Mar – Aug 2022', 'Mar – Ago 2022')}</div>
+        <div className="mb-[30px] flex w-full flex-col">
+          <div className="relative mb-3.5 flex justify-between">
+            <div className="absolute -left-[30px] top-[5px] h-[15px] w-[15px] rounded-full bg-darkOrange max-lg:hidden" />
+            <span className="mb-[15px] font-poppins-semibold text-xl text-darkOrange">{t('Machine Learning Researcher', 'Investigador en Machine Learning')}</span>
+            <div className="flex h-[27px] w-[120px] items-center justify-center rounded-[14px] bg-darkOrange px-[14px] py-1 text-sm text-uiWhite">{t('Mar – Aug 2022', 'Mar – Ago 2022')}</div>
           </div>
-          <div className="resume-sub-heading">
+          <div className="mb-[15px] mt-[-5px] ml-[10px] text-[15px] text-uiBlack">
             <span>
               Instituto de Innovación y Tecnología Aplicada{' '}
-              <a className="link" href="https://iita.com.ar/">(IITA)</a>
+              <a className="font-bold text-[#1f2235] transition-colors hover:text-darkOrange" href="https://iita.com.ar/" target="_blank" rel="noopener noreferrer">(IITA)</a>
             </span>
           </div>
-          <div className="resume-heading-description">
+          <div className="mb-[15px] ml-[15px] mt-[10px] text-justify text-[13px] leading-normal">
             <span>{t('Developed Deep Q-learning systems and automated ML pipelines.', 'Desarrollo de sistemas Deep Q-learning y automatización de pipelines ML.')}</span>
           </div>
         </div>
-        <div className="experience-description">
-          <span className="resume-description-text">
+        <div className="mb-2.5 mt-2.5 max-w-full text-justify">
+          <span className="text-xs">
             - {t(
               'Built ML test environment on GCE using MLFlow, increasing iteration speed by 25%.',
               'Construcción de entorno ML en GCE con MLFlow, mejorando la iteración en un 25%.'
@@ -156,24 +156,24 @@ const Work: React.FunctionComponent<object> = () => {
         </div>
 
         {/* UCASAL */}
-        <div className="resume-heading">
-          <div className="resume-main-heading">
-            <div className="heading-bullet" />
-            <span>{t('Student Researcher', 'Alumno Investigador')}</span>
-            <div className="heading-date">{t('Aug 21 – Dec 24', 'Ago 21 – Dic 24')}</div>
+        <div className="mb-[30px] flex w-full flex-col">
+          <div className="relative mb-3.5 flex justify-between">
+            <div className="absolute -left-[30px] top-[5px] h-[15px] w-[15px] rounded-full bg-darkOrange max-lg:hidden" />
+            <span className="mb-[15px] font-poppins-semibold text-xl text-darkOrange">{t('Student Researcher', 'Alumno Investigador')}</span>
+            <div className="flex h-[27px] w-[120px] items-center justify-center rounded-[14px] bg-darkOrange px-[14px] py-1 text-sm text-uiWhite">{t('Aug 21 – Dec 24', 'Ago 21 – Dic 24')}</div>
           </div>
-          <div className="resume-sub-heading">
+          <div className="mb-[15px] mt-[-5px] ml-[10px] text-[15px] text-uiBlack">
             <span>
               {t('Engineering Faculty at', 'Facultad de Ingeniería en')}{' '}
-              <a className="link" href="https://www.ucasal.edu.ar/">UCASAL</a>
+              <a className="font-bold text-[#1f2235] transition-colors hover:text-darkOrange" href="https://www.ucasal.edu.ar/" target="_blank" rel="noopener noreferrer">UCASAL</a>
             </span>
           </div>
-          <div className="resume-heading-description">
+          <div className="mb-[15px] ml-[15px] mt-[10px] text-justify text-[13px] leading-normal">
             <span>{t('Digital forensics and metaverse research.', 'Forensia digital e investigación en metaversos.')}</span>
           </div>
         </div>
-        <div className="experience-description">
-          <span className="resume-description-text">
+        <div className="mb-2.5 mt-2.5 max-w-full text-justify">
+          <span className="text-xs">
             - {t(
               'Developed KeyWordFinder with Electron and Vue.js, improving processing by 20%.',
               'Desarrollo de KeyWordFinder con Electron y Vue.js, mejorando el rendimiento en un 20%.'
@@ -190,24 +190,24 @@ const Work: React.FunctionComponent<object> = () => {
         </div>
 
         {/* IITA Tutor */}
-        <div className="resume-heading">
-          <div className="resume-main-heading">
-            <div className="heading-bullet" />
-            <span>{t('Python Programming Tutor', 'Tutor de Programación en Python')}</span>
-            <div className="heading-date">2021 – 2022</div>
+        <div className="mb-[30px] flex w-full flex-col">
+          <div className="relative mb-3.5 flex justify-between">
+            <div className="absolute -left-[30px] top-[5px] h-[15px] w-[15px] rounded-full bg-darkOrange max-lg:hidden" />
+            <span className="mb-[15px] font-poppins-semibold text-xl text-darkOrange">{t('Python Programming Tutor', 'Tutor de Programación en Python')}</span>
+            <div className="flex h-[27px] w-[120px] items-center justify-center rounded-[14px] bg-darkOrange px-[14px] py-1 text-sm text-uiWhite">2021 – 2022</div>
           </div>
-          <div className="resume-sub-heading">
+          <div className="mb-[15px] mt-[-5px] ml-[10px] text-[15px] text-uiBlack">
             <span>
               Instituto de Innovación y Tecnología Aplicada{' '}
-              <a className="link" href="https://iita.com.ar/">(IITA)</a>
+              <a className="font-bold text-[#1f2235] transition-colors hover:text-darkOrange" href="https://iita.com.ar/" target="_blank" rel="noopener noreferrer">(IITA)</a>
             </span>
           </div>
-          <div className="resume-heading-description">
+          <div className="mb-[15px] ml-[15px] mt-[10px] text-justify text-[13px] leading-normal">
             <span>{t('Led weekly lectures and mentored students.', 'Clases semanales y mentoría de alumnos.')}</span>
           </div>
         </div>
-        <div className="experience-description">
-          <span className="resume-description-text">
+        <div className="mb-2.5 mt-2.5 max-w-full text-justify">
+          <span className="text-xs">
             - {t(
               'Prepared and taught course content, evaluated assignments.',
               'Preparación y dictado de clases, corrección de actividades.'

--- a/styles/base/_gobal.css
+++ b/styles/base/_gobal.css
@@ -33,6 +33,87 @@ body ::-webkit-scrollbar-thumb {
   background: hsla(0, 0%, 100%, 0.1);
 }
 
+.fade-in {
+  opacity: 0;
+  transform: translateY(80px);
+  transition: all 0.8s ease;
+}
+
+.appear {
+  opacity: 1;
+  transform: translateY(0px);
+  transition: all 0.8s ease;
+}
+
+.heading-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  margin: 0 0 50px;
+}
+
+.screen-sub-heading {
+  letter-spacing: 3px;
+  margin: 8px 0 10px;
+  font-size: 12px;
+  color: var(--black);
+}
+
+.screen-heading {
+  font-size: 32px;
+  color: #1f2235;
+  font-family: var(--font-poppins-bold), sans-serif;
+}
+
+.heading-seperator {
+  display: flex;
+  align-items: center;
+  position: relative;
+  width: 180px;
+  margin: 10px 0 0;
+}
+
+.seperator-line {
+  width: 100%;
+  height: 2px;
+  background-color: #1f221f;
+}
+
+.seperator-blob {
+  height: 10px;
+  width: 100%;
+  position: absolute;
+  display: flex;
+  justify-content: center;
+}
+
+.seperator-blob div {
+  width: 35px;
+  border-radius: 10px;
+  background-color: var(--dark-orange);
+}
+
+@keyframes fadeInAnimation {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes loading {
+  0% {
+    left: -30%;
+  }
+
+  100% {
+    left: 100%;
+  }
+}
+
 @keyframes inAnimation {
   0% {
     transform: translateX(-50%) scaleY(0);

--- a/styles/main.css
+++ b/styles/main.css
@@ -2,13 +2,9 @@
 @import './base/_variables.css';
 @import './base/_gobal.css';
 @import './components/_profile.css';
-@import './components/_aboutMe.css';
-@import './components/_resume.css';
 @import './components/_badges.css';
 @import './components/_badge.css';
 @import './components/_contactMe.css';
-@import './pages/_projects.css';
-@import './components/_loadingBar.css';
 
 @tailwind base;
 @tailwind components;


### PR DESCRIPTION
## Summary
- migrate About, Resume, and Projects slices to Tailwind utility classes with high visual parity
- preserve interaction patterns (resume tabs, project navigation, responsive cards)
- remove legacy CSS ownership for this slice from active imports and move shared section primitives to global base styles

## Verification
- `npm run lint`
- `npm run build`
- `npm run build && npm run typecheck`

Closes #17