### PR TITLE
feat: centralize EN/ES content and normalize copy

### DIFF
--- a/components/AboutMe.tsx
+++ b/components/AboutMe.tsx
@@ -4,9 +4,11 @@ import React, { useContext } from 'react'
 import { useInView } from 'react-intersection-observer'
 import { ILanguageContextType } from '../@types/language.types'
 import { LanguageContext } from '../context/LanguageContextProvider'
+import { copy, toLocale } from '../content/i18n'
 
 const AboutMe = () => {
   const { language } = useContext(LanguageContext) as ILanguageContextType
+  const locale = toLocale(language.name)
 
   const { ref, inView } = useInView({
     threshold: 0.3
@@ -23,14 +25,10 @@ const AboutMe = () => {
       >
         <div className="heading-container">
           <div className="screen-heading">
-            <span>{language.name === 'en' ? 'About Me' : 'Sobre Mí'}</span>
+            <span>{copy.sections.aboutTitle[locale]}</span>
           </div>
           <div className="screen-sub-heading">
-            <span>
-              {language.name === 'en'
-                ? 'A Brief Overview'
-                : 'Una Breve Descripción'}
-            </span>
+            <span>{copy.sections.aboutSubtitle[locale]}</span>
           </div>
           <div className="heading-seperator">
             <div className="seperator-line"></div>
@@ -184,7 +182,7 @@ const AboutMe = () => {
                 href="/#ContactMe"
                 className="w-full rounded-[50px] border-2 border-[linen] bg-[#1f2235] py-3.5 text-center font-poppins-semibold text-xs text-uiWhite transition hover:border-darkOrange hover:text-[#f0f8ff] sm:w-[160px]"
               >
-                {language.name === 'en' ? 'Contact Me' : 'Contáctame'}
+                {copy.sections.contactButton[locale]}
               </Link>
               <button
                 name="ContactMe"
@@ -198,7 +196,7 @@ const AboutMe = () => {
                   window.open(cvUrl, '_blank')
                 }}
               >
-                {language.name === 'en' ? 'Get Resume' : 'Descargar CV'}
+                {copy.sections.resumeButton[locale]}
               </button>
             </div>
           </div>

--- a/components/Badges.tsx
+++ b/components/Badges.tsx
@@ -6,9 +6,11 @@ import badgesData from '../badges.json'
 import { useInView } from 'react-intersection-observer'
 import { LanguageContext } from '../context/LanguageContextProvider'
 import { ILanguageContextType } from '../@types/language.types'
+import { copy, toLocale } from '../content/i18n'
 
 const Badges = () => {
   const { language } = useContext(LanguageContext) as ILanguageContextType
+  const locale = toLocale(language.name)
   const [selectedIndex, setSelectedIndex] = useState(0)
   const [scrollSnaps, setScrollSnaps] = useState<number[]>([])
   const [canScrollPrev, setCanScrollPrev] = useState(false)
@@ -64,14 +66,10 @@ const Badges = () => {
         className={`mt-[200px] flex w-full flex-col items-center ${inView ? 'appear' : ''} fade-in`}
       >
         <div className="screen-heading">
-          <span>{language.name === 'en' ? 'Badges' : 'Premios'}</span>
+          <span>{copy.sections.badgesTitle[locale]}</span>
         </div>
         <div className="screen-sub-heading">
-          <span>
-            {language.name === 'en'
-              ? 'Workshops Hackathons and Challenges'
-              : 'Workshops Hackathons y Desafios'}
-          </span>
+          <span>{copy.sections.badgesSubtitle[locale]}</span>
         </div>
         <div className="heading-seperator">
           <div className="seperator-line"></div>

--- a/components/ContactMe.tsx
+++ b/components/ContactMe.tsx
@@ -9,9 +9,12 @@ import useContactForm from '../hooks/useContactForm'
 import { useInView } from 'react-intersection-observer'
 import { LanguageContext } from '../context/LanguageContextProvider'
 import { ILanguageContextType } from '../@types/language.types'
+import { copy, toLocale } from '../content/i18n'
 import Image from 'next/image'
+
 const ContactMe: React.FunctionComponent<object> = () => {
   const { language } = useContext(LanguageContext) as ILanguageContextType
+  const locale = toLocale(language.name)
 
   const { ref, inView } = useInView({
     threshold: 0.3
@@ -48,14 +51,10 @@ const ContactMe: React.FunctionComponent<object> = () => {
     <section ref={ref} className="min-h-screen bg-uiWhite pb-8 pt-[70px]" id="ContactMe">
       <div className={`heading-container ${inView ? 'appear' : ''} fade-in`}>
         <div className="screen-heading">
-          <span>{language.name === 'en' ? 'Contact Me' : 'Contactame'}</span>
+          <span>{copy.sections.contactTitle[locale]}</span>
         </div>
         <div className="screen-sub-heading">
-          <span>
-            {language.name === 'en'
-              ? 'Lets Keep In Touch'
-              : 'Estemos en Contacto'}
-          </span>
+          <span>{copy.sections.contactSubtitle[locale]}</span>
         </div>
         <div className="heading-seperator">
           <div className="seperator-line"></div>
@@ -71,14 +70,10 @@ const ContactMe: React.FunctionComponent<object> = () => {
         <div className="min-w-0 flex-1">
           <h2 className="mb-5 font-poppins-bold text-xl tracking-[0.2rem] text-uiWhite">
             {prefersReducedMotion ? (
-              language.name === 'en' ? 'Get in Touch 📧' : 'Ponte en Contacto 📧'
+              copy.sections.contactHeading[locale]
             ) : (
               <TypeAnimation
-                sequence={
-                  language.name === 'en'
-                    ? ['Get in Touch 📧', 1000]
-                    : ['Ponte en Contacto 📧', 1000]
-                }
+                sequence={[copy.sections.contactHeading[locale], 1000]}
                 repeat={Infinity}
                 speed={50}
               />
@@ -90,9 +85,7 @@ const ContactMe: React.FunctionComponent<object> = () => {
         <div className="mx-auto mt-8 flex w-full max-w-[1100px] flex-col justify-between gap-5 lg:flex-row">
           <div className="w-full lg:flex-1">
             <h2 className="mb-4 text-lg font-normal tracking-[0.3rem] text-uiWhite/60">
-              {language.name === 'en'
-                ? 'Send Your Email Here!'
-                : 'Envia tu Email aquí!'}
+              {copy.sections.contactFormHeading[locale]}
             </h2>
             <Image
               src="/assets/ContactMe/mail.jpeg"
@@ -123,7 +116,7 @@ const ContactMe: React.FunctionComponent<object> = () => {
             )}
 
             <label htmlFor="name">
-              {language.name === 'en' ? 'Name' : 'Nombre'}
+              {copy.sections.contactName[locale]}
             </label>
             <input
               id="name"
@@ -150,7 +143,7 @@ const ContactMe: React.FunctionComponent<object> = () => {
             />
 
             <label htmlFor="message">
-              {language.name === 'en' ? 'Message' : 'Mensaje'}
+              {copy.sections.contactMessage[locale]}
             </label>
             <textarea
               id="message"
@@ -172,12 +165,8 @@ const ContactMe: React.FunctionComponent<object> = () => {
                 className="mt-4 flex w-40 items-center justify-center rounded-[19px] border-2 border-darkOrange bg-[#1f2235] p-1 text-lg text-[#e6e3e3] transition hover:border-[#1f2235] disabled:cursor-not-allowed disabled:opacity-70"
               >
                 {isSubmitting
-                  ? language.name === 'en'
-                    ? 'Sending...'
-                    : 'Enviando...'
-                  : language.name === 'en'
-                    ? 'Send'
-                    : 'Enviar'}{' '}
+                  ? copy.sections.contactSending[locale]
+                  : copy.sections.contactSend[locale]}{' '}
                 <FontAwesomeIcon icon={faPaperPlane}></FontAwesomeIcon>
               </button>
             </div>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -4,6 +4,7 @@ import { usePathname } from 'next/navigation'
 import React, { Dispatch, SetStateAction, useContext } from 'react'
 import { ILanguageContextType } from '../@types/language.types'
 import { LanguageContext } from '../context/LanguageContextProvider'
+import { copy, toLocale } from '../content/i18n'
 import useNavBar from '../hooks/useNavBar'
 
 const Header: React.FunctionComponent<{
@@ -21,6 +22,7 @@ const Header: React.FunctionComponent<{
   ] = useNavBar()
   const pathname = usePathname()
   const { language } = useContext(LanguageContext) as ILanguageContextType
+  const locale = toLocale(language.name)
   const baseOptionClass =
     'text-xl font-extrabold transition-colors hover:text-darkOrange lg:text-base'
   const selectedOptionClass = 'text-darkOrange'
@@ -73,7 +75,7 @@ const Header: React.FunctionComponent<{
           >
             <span onClick={() => handleSectionClick('home')}>
               <Link href={pathname === '/projects' ? '/' : '/#Home'}>
-                {language.name === 'en' ? 'Home' : 'Inicio'}
+                {copy.nav.home[locale]}
               </Link>
             </span>
           </div>
@@ -85,7 +87,7 @@ const Header: React.FunctionComponent<{
               >
                 <span onClick={() => handleSectionClick('about-me')}>
                   <Link href="/#AboutMe">
-                    {language.name === 'en' ? 'AboutMe' : 'Sobre mi'}
+                    {copy.nav.about[locale]}
                   </Link>
                 </span>
               </div>
@@ -94,7 +96,7 @@ const Header: React.FunctionComponent<{
               >
                 <span onClick={() => handleSectionClick('resume')}>
                   <Link href="/#Resume">
-                    {language.name === 'en' ? 'Resume' : 'Trayectoria'}
+                    {copy.nav.resume[locale]}
                   </Link>
                 </span>
               </div>
@@ -103,7 +105,7 @@ const Header: React.FunctionComponent<{
               >
                 <span onClick={() => handleSectionClick('badges')}>
                   <Link href="/#Badges">
-                    {language.name === 'en' ? 'Badges' : 'Premios'}
+                    {copy.nav.badges[locale]}
                   </Link>
                 </span>
               </div>
@@ -112,7 +114,7 @@ const Header: React.FunctionComponent<{
               >
                 <span onClick={() => handleSectionClick('projects')}>
                   <Link href="/projects">
-                    {language.name === 'en' ? 'Projects' : 'Proyectos'}
+                    {copy.nav.projects[locale]}
                   </Link>
                 </span>
               </div>
@@ -121,7 +123,7 @@ const Header: React.FunctionComponent<{
               >
                 <span onClick={() => handleSectionClick('contact-me')}>
                   <Link href="/#ContactMe">
-                    {language.name === 'en' ? 'ContactMe' : 'Contactame'}
+                    {copy.nav.contact[locale]}
                   </Link>
                 </span>
               </div>
@@ -133,7 +135,7 @@ const Header: React.FunctionComponent<{
             >
               <span onClick={() => handleSectionClick('projects')}>
                 <Link href="/projects">
-                  {language.name === 'en' ? 'Projects' : 'Proyectos'}
+                  {copy.nav.projects[locale]}
                 </Link>
               </span>
             </div>

--- a/components/Profile.tsx
+++ b/components/Profile.tsx
@@ -2,6 +2,7 @@
 import React, { useContext } from 'react'
 import { ILanguageContextType } from '../@types/language.types'
 import { LanguageContext } from '../context/LanguageContextProvider'
+import { copy, toLocale } from '../content/i18n'
 import Icons from './Icons'
 import Image from 'next/image'
 import { TypeAnimation } from 'react-type-animation'
@@ -23,6 +24,7 @@ const steps = [
 ]
 const Profile: React.FunctionComponent<object> = () => {
   const { language } = useContext(LanguageContext) as ILanguageContextType
+  const locale = toLocale(language.name)
 
   return (
     <div
@@ -65,7 +67,8 @@ const Profile: React.FunctionComponent<object> = () => {
               className="w-[140px] rounded-[50px] border-2 border-[linen] bg-[#1f2235] py-3.5 text-center font-poppins-semibold text-xs text-uiWhite transition hover:border-darkOrange hover:text-[#f0f8ff]"
             >
               {''}
-              {language.name === 'en' ? ' Get in Touch' : 'Contactar'}
+              {' '}
+              {copy.sections.contactButton[locale]}
             </Link>
             <button
               className="w-[140px] rounded-[50px] bg-darkOrange py-3.5 font-poppins-semibold text-xs text-uiWhite transition hover:bg-[#fff8dc] hover:text-[#111]"
@@ -78,7 +81,7 @@ const Profile: React.FunctionComponent<object> = () => {
                 window.open(cvUrl, '_blank')
               }}
             >
-              {language.name === 'en' ? 'Get Resume' : 'Descargar CV'}
+              {copy.sections.resumeButton[locale]}
             </button>
           </div>
         </div>

--- a/components/ResumeComponents/Proyects.tsx
+++ b/components/ResumeComponents/Proyects.tsx
@@ -5,11 +5,13 @@ import Link from 'next/link'
 import React, { useContext } from 'react'
 import { ILanguageContextType } from '../../@types/language.types'
 import { LanguageContext } from '../../context/LanguageContextProvider'
+import { copy, toLocale } from '../../content/i18n'
 import { useRouter } from 'next/navigation'
 
 const Proyects: React.FunctionComponent<object> = () => {
   const router = useRouter()
   const { language } = useContext(LanguageContext) as ILanguageContextType
+  const locale = toLocale(language.name)
 
   return (
     <div className="animate-[fadeInAnimation_2s]">
@@ -138,7 +140,7 @@ const Proyects: React.FunctionComponent<object> = () => {
             onClick={() => router.push('/projects')}
             className="mt-4 w-40 rounded-[19px] border-2 border-darkOrange bg-[#1f2235] p-1 text-[11px] text-[#e6e3e3] transition hover:border-[#1f2235] hover:bg-darkOrange hover:text-uiBlack"
           >
-            {language.name === 'en' ? 'More Projects' : 'Mas Proyectos'}{' '}
+            {copy.sections.moreProjects[locale]}{' '}
             <FontAwesomeIcon icon={faGithub} />
           </button>
         </div>

--- a/content/i18n.ts
+++ b/content/i18n.ts
@@ -1,0 +1,35 @@
+export type Locale = 'en' | 'es'
+
+export const copy = {
+  nav: {
+    home: { en: 'Home', es: 'Inicio' },
+    about: { en: 'About Me', es: 'Sobre mí' },
+    resume: { en: 'Resume', es: 'Trayectoria' },
+    badges: { en: 'Badges', es: 'Premios' },
+    projects: { en: 'Projects', es: 'Proyectos' },
+    contact: { en: 'Contact Me', es: 'Contáctame' }
+  },
+  sections: {
+    aboutTitle: { en: 'About Me', es: 'Sobre mí' },
+    aboutSubtitle: { en: 'A Brief Overview', es: 'Una breve descripción' },
+    badgesTitle: { en: 'Badges', es: 'Premios' },
+    badgesSubtitle: {
+      en: 'Workshops, Hackathons, and Challenges',
+      es: 'Workshops, hackathons y desafíos'
+    },
+    contactTitle: { en: 'Contact Me', es: 'Contáctame' },
+    contactSubtitle: { en: "Let's Keep in Touch", es: 'Mantengámonos en contacto' },
+    contactHeading: { en: 'Get in Touch 📧', es: 'Ponte en contacto 📧' },
+    contactFormHeading: { en: 'Send Your Email Here!', es: '¡Envía tu email aquí!' },
+    contactName: { en: 'Name', es: 'Nombre' },
+    contactMessage: { en: 'Message', es: 'Mensaje' },
+    contactSend: { en: 'Send', es: 'Enviar' },
+    contactSending: { en: 'Sending...', es: 'Enviando...' },
+    contactButton: { en: 'Contact Me', es: 'Contáctame' },
+    resumeButton: { en: 'Get Resume', es: 'Descargar CV' },
+    moreProjects: { en: 'More Projects', es: 'Más Proyectos' }
+  }
+} as const
+
+export const toLocale = (languageName: string): Locale =>
+  languageName === 'es' ? 'es' : 'en'


### PR DESCRIPTION
## Summary
- introduce centralized bilingual copy dictionary in `content/i18n.ts`
- wire key migrated sections to shared EN/ES text keys to reduce string drift
- correct user-visible copy inconsistencies while preserving behavior and intent

## Verification
- `npm run lint`
- `npm run build`
- `npm run build && npm run typecheck`

Closes #19