### PR TITLE
feat: modernize visual language while keeping portfolio narrative

### DIFF
--- a/components/AboutMe.tsx
+++ b/components/AboutMe.tsx
@@ -6,7 +6,7 @@ import { Locale, localePath } from '../lib/i18n'
 const AboutMe = ({ locale }: { locale: Locale }) => {
   return (
     <section
-      className="-mt-1 mb-12 flex w-full flex-col items-center justify-center bg-uiWhite"
+      className="-mt-1 mb-12 flex w-full flex-col items-center justify-center bg-[#f7f8fc] pt-6"
       id="AboutMe"
     >
       <div className="w-[88%] max-w-[1000px] lg:w-[70%] fade-in appear">
@@ -25,7 +25,7 @@ const AboutMe = ({ locale }: { locale: Locale }) => {
           </div>
         </div>
 
-        <div className="mb-8 flex w-full overflow-hidden shadow-[0_0_20px_-2px_#1f2235]">
+        <div className="mb-8 flex w-full overflow-hidden rounded-[26px] border border-[#1f2235]/10 bg-white shadow-[0_30px_60px_-45px_#1f2235]">
           <div className="hidden w-1/2 bg-[url('/assets/home/aboutMe.jpeg')] bg-cover bg-[position:25%] bg-no-repeat lg:block"></div>
           <div className="w-full p-8 text-justify lg:w-[48%]">
             <span className="text-[13px] font-[450]">

--- a/components/Badges.tsx
+++ b/components/Badges.tsx
@@ -56,7 +56,7 @@ const Badges = ({ locale }: { locale: Locale }) => {
   return (
     <section
       ref={ref}
-      className="mb-12 flex w-full flex-col justify-between bg-uiWhite"
+      className="mb-12 flex w-full flex-col justify-between bg-[#f7f8fc]"
       id="Badges"
     >
       <div
@@ -76,7 +76,7 @@ const Badges = ({ locale }: { locale: Locale }) => {
         </div>
       </div>
 
-      <div className="w-full bg-[#24263C] px-0 py-20">
+      <div className="w-full bg-gradient-to-br from-[#1a1f34] via-[#212841] to-[#1b2238] px-0 py-20">
         <div className={`flex items-center gap-2 px-3 ${inView ? 'appear' : ''} fade-in`}>
           <button
             className="h-10 w-10 rounded-full bg-darkOrange text-2xl leading-none text-uiWhite transition hover:bg-uiWhite hover:text-darkOrange disabled:cursor-not-allowed disabled:opacity-60"

--- a/components/ContactMe.tsx
+++ b/components/ContactMe.tsx
@@ -45,7 +45,7 @@ const ContactMe = ({ locale }: { locale: Locale }) => {
   ] = useContactForm()
 
   return (
-    <section ref={ref} className="min-h-screen bg-uiWhite pb-8 pt-[70px]" id="ContactMe">
+    <section ref={ref} className="min-h-screen bg-[#f7f8fc] pb-8 pt-[70px]" id="ContactMe">
       <div className={`heading-container ${inView ? 'appear' : ''} fade-in`}>
         <div className="screen-heading">
           <span>{copy.sections.contactTitle[locale]}</span>
@@ -62,7 +62,7 @@ const ContactMe = ({ locale }: { locale: Locale }) => {
       </div>
 
       <div
-        className={`${inView ? 'appear' : ''} mx-auto flex max-w-[1100px] flex-col rounded-xl bg-[#1f2235] p-2.5 text-uiWhite shadow-[0_0_20px_-2px_#1f2235] fade-in`}
+        className={`${inView ? 'appear' : ''} mx-auto flex max-w-[1100px] flex-col rounded-[28px] border border-[#1f2235]/10 bg-gradient-to-br from-[#1a1f34] via-[#1f2235] to-[#252c47] p-3 text-uiWhite shadow-[0_30px_70px_-48px_#1f2235] fade-in`}
       >
         <div className="min-w-0 flex-1">
           <h2 className="mb-5 font-poppins-bold text-xl tracking-[0.2rem] text-uiWhite">

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -21,7 +21,7 @@ const Header = ({ locale }: { locale: Locale }) => {
   const pathname = usePathname()
 
   const baseOptionClass =
-    'text-xl font-extrabold transition-colors hover:text-darkOrange lg:text-base'
+    'rounded-full px-3 py-1.5 text-xl font-extrabold transition-all hover:bg-white/10 hover:text-darkOrange lg:text-base'
   const selectedOptionClass = 'text-darkOrange'
 
   const handleSectionClick = (sectionName: string) => {
@@ -60,11 +60,11 @@ const Header = ({ locale }: { locale: Locale }) => {
         </button>
 
         <div className="font-poppins-extrabold text-4xl text-uiWhite lg:text-5xl">
-          <span>Alejo Torres</span>
+          <span className="bg-gradient-to-r from-[#fff] via-[#ffe5d9] to-[#ff6a4f] bg-clip-text text-transparent">Alejo Torres</span>
         </div>
 
         <div
-          className={`absolute left-0 top-[110px] z-[1000] flex h-[calc(100vh-110px)] w-full flex-col justify-around bg-[#1f2235] px-10 text-base font-semibold transition-transform duration-500 lg:static lg:h-auto lg:w-auto lg:translate-x-0 lg:flex-row lg:items-center lg:gap-12 lg:bg-transparent lg:px-0 ${
+          className={`absolute left-0 top-[110px] z-[1000] flex h-[calc(100vh-110px)] w-full flex-col justify-around bg-[#151b2f]/95 px-10 text-base font-semibold backdrop-blur-md transition-transform duration-500 lg:static lg:h-auto lg:w-auto lg:translate-x-0 lg:flex-row lg:items-center lg:gap-8 lg:rounded-full lg:border lg:border-white/15 lg:bg-[#1b2139]/55 lg:px-6 lg:py-2 lg:shadow-[0_20px_40px_-24px_rgba(0,0,0,0.8)] ${
             showMobileMenu
               ? 'translate-x-0 opacity-100'
               : '-translate-x-[120%] opacity-0 lg:opacity-100'

--- a/components/LocaleSwitcher.tsx
+++ b/components/LocaleSwitcher.tsx
@@ -3,7 +3,7 @@ import { Locale, localePath, locales } from '../lib/i18n'
 
 const LocaleSwitcher = ({ locale }: { locale: Locale }) => {
   return (
-    <div className="relative z-[1000] mr-8 flex h-[30px] items-center justify-end gap-2 text-uiWhite lg:mr-20">
+    <div className="relative z-[1000] mr-8 flex h-[38px] items-center justify-end gap-2 pt-3 text-uiWhite lg:mr-20">
       {locales.map((localeOption) => {
         const isActive = localeOption === locale
 
@@ -13,8 +13,8 @@ const LocaleSwitcher = ({ locale }: { locale: Locale }) => {
             href={localePath(localeOption)}
             className={`rounded px-3 py-1.5 font-poppins-semibold text-base font-semibold transition-colors ${
               isActive
-                ? 'bg-darkOrange text-uiWhite'
-                : 'bg-white/10 hover:bg-white/20'
+                ? 'bg-darkOrange text-uiWhite shadow-[0_10px_20px_-12px_rgba(255,106,79,0.85)]'
+                : 'border border-white/25 bg-white/10 hover:bg-white/20'
             }`}
           >
             {localeOption.toUpperCase()}

--- a/components/Profile.tsx
+++ b/components/Profile.tsx
@@ -25,17 +25,17 @@ const Profile = ({ locale }: { locale: Locale }) => {
 
   return (
     <div
-      className="flex min-h-fit w-full items-center justify-center bg-[#24263c] px-4 text-center"
+      className="relative flex min-h-fit w-full items-center justify-center bg-transparent px-4 pb-8 text-center"
       id="Home"
     >
-      <div className="mt-10 flex w-full max-w-[1120px] flex-col-reverse items-center text-[#f0f8ff] md:mt-4 md:flex-row md:justify-between">
+      <div className="mt-12 flex w-full max-w-[1120px] flex-col-reverse items-center text-[#f0f8ff] md:mt-6 md:flex-row md:justify-between">
         <div>
           <div>
             <div>
               <Icons />
             </div>
           </div>
-          <div className="font-poppins-semibold text-2xl">
+          <div className="font-poppins-semibold text-[26px]">
               <span className="text-uiWhite">
                 {''}
                 {locale === 'en'
@@ -47,7 +47,7 @@ const Profile = ({ locale }: { locale: Locale }) => {
           <div className="my-3.5 flex flex-col">
             <span className="text-uiWhite">
               {''}
-              <h1 className="mx-auto flex h-[60px] min-w-[320px] items-center justify-center text-center font-[cursive] text-[28px] md:min-w-[420px] md:text-[40px]">
+              <h1 className="mx-auto flex h-[60px] min-w-[320px] items-center justify-center text-center font-[cursive] text-[30px] md:min-w-[420px] md:text-[42px]">
                 {''}
                 <TypeAnimation sequence={steps} repeat={Infinity} speed={50} />
               </h1>
@@ -61,7 +61,7 @@ const Profile = ({ locale }: { locale: Locale }) => {
           <div className="flex items-center justify-center gap-4 md:justify-start">
             <Link
               href={localePath(locale, '#ContactMe')}
-              className="w-[140px] rounded-[50px] border-2 border-[linen] bg-[#1f2235] py-3.5 text-center font-poppins-semibold text-xs text-uiWhite transition hover:border-darkOrange hover:text-[#f0f8ff]"
+              className="w-[140px] rounded-[50px] border border-white/40 bg-[#101527]/85 py-3.5 text-center font-poppins-semibold text-xs text-uiWhite shadow-[0_16px_30px_-22px_rgba(255,255,255,0.7)] transition hover:border-darkOrange hover:bg-[#1f2235] hover:text-[#f0f8ff]"
             >
               {''}
               {' '}
@@ -75,13 +75,14 @@ const Profile = ({ locale }: { locale: Locale }) => {
               }
               target="_blank"
               rel="noopener noreferrer"
-              className="w-[140px] rounded-[50px] bg-darkOrange py-3.5 font-poppins-semibold text-xs text-uiWhite transition hover:bg-[#fff8dc] hover:text-[#111]"
+              className="w-[140px] rounded-[50px] bg-gradient-to-r from-[#ff764f] to-[#ff4b2f] py-3.5 font-poppins-semibold text-xs text-uiWhite shadow-[0_18px_30px_-20px_rgba(255,106,79,0.95)] transition hover:from-[#fff8dc] hover:to-[#ffd5a7] hover:text-[#111]"
             >
               {copy.sections.resumeButton[locale]}
             </Link>
           </div>
         </div>
-        <div className="mb-10 mt-4 flex h-[275px] w-[275px] items-center justify-center rounded-full shadow-[0_1px_0_0.5px_var(--white)] sm:h-[320px] sm:w-[320px] md:mb-24 md:h-[380px] md:w-[380px] md:ml-20 lg:ml-1">
+        <div className="relative mb-10 mt-4 flex h-[275px] w-[275px] items-center justify-center rounded-full border border-white/20 bg-white/5 shadow-[0_20px_45px_-24px_rgba(0,0,0,0.8)] sm:h-[320px] sm:w-[320px] md:mb-24 md:h-[380px] md:w-[380px] md:ml-20 lg:ml-1">
+          <div className="absolute inset-2 rounded-full bg-gradient-to-br from-[#ff6a4f33] to-[#26b0ce2f] blur-md"></div>
           <div className="h-[93%] w-[93%] rounded-full bg-cover bg-center bg-no-repeat transition duration-1000 ease-out hover:scale-105">
             <Image
               className="rounded-full"

--- a/components/Project.tsx
+++ b/components/Project.tsx
@@ -14,7 +14,7 @@ type props = {
 
 const Project = ({ name, description, image, knowMore, date }: props) => {
   return (
-    <article className="relative col-span-12 flex cursor-pointer flex-col bg-[#2c2e44] transition-all duration-300 hover:-translate-y-[7px] md:col-span-6 xl:col-span-4">
+    <article className="relative col-span-12 flex cursor-pointer flex-col overflow-hidden rounded-[22px] border border-white/10 bg-gradient-to-b from-[#2b304a] to-[#1f243a] transition-all duration-300 hover:-translate-y-[7px] hover:shadow-[0_24px_40px_-28px_rgba(0,0,0,0.8)] md:col-span-6 xl:col-span-4">
       <div className="relative w-full overflow-hidden pt-[56.25%]">
         <Image
           src={image}

--- a/components/Resume.tsx
+++ b/components/Resume.tsx
@@ -40,7 +40,7 @@ const Resume = ({ locale }: { locale: Locale }) => {
   return (
     <section
       ref={ref}
-      className="-my-12 flex min-h-fit w-full flex-col items-center justify-center bg-uiWhite"
+      className="-my-12 flex min-h-fit w-full flex-col items-center justify-center bg-[#f7f8fc]"
       id="Resume"
     >
       <div className={`mt-[200px] w-full ${inView ? 'appear' : ''} fade-in`}>
@@ -64,9 +64,9 @@ const Resume = ({ locale }: { locale: Locale }) => {
         </div>
 
         <div className="mx-auto mb-20 flex h-auto w-[90%] max-w-[1000px] flex-col items-center lg:h-[360px] lg:flex-row lg:items-stretch">
-          <div className="my-[30px] w-full shadow-[15px_0_9px_-15px_#1f2235] lg:my-0 lg:w-[320px]">
+          <div className="my-[30px] w-full rounded-[22px] border border-[#1f2235]/10 bg-white p-2 shadow-[0_24px_40px_-32px_#1f2235] lg:my-0 lg:w-[320px]">
             <div className="relative flex h-full w-full items-center">
-              <div className="absolute z-[1] h-full w-[34px] bg-[#1f2235]"></div>
+              <div className="absolute z-[1] h-full w-[34px] rounded-l-[18px] bg-[#1f2235]"></div>
               <div className="relative z-[2] w-[90%] lg:w-[86%]">
                 <div
                   onClick={() => toggleSection('education')}

--- a/styles/base/_gobal.css
+++ b/styles/base/_gobal.css
@@ -1,11 +1,38 @@
 
 .home-container {
+  position: relative;
+  overflow: hidden;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   min-height: 670px;
-  background-color: #24263C;
+  background:
+    radial-gradient(circle at 14% 12%, rgba(255, 88, 76, 0.22), transparent 38%),
+    radial-gradient(circle at 86% 8%, rgba(38, 176, 206, 0.2), transparent 36%),
+    linear-gradient(140deg, #131628 0%, #1d2138 48%, #272641 100%);
   width: 100%;
+}
+
+.home-container::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image: linear-gradient(
+      115deg,
+      rgba(255, 255, 255, 0.05) 0,
+      rgba(255, 255, 255, 0.05) 1px,
+      transparent 1px,
+      transparent 16px
+    ),
+    linear-gradient(
+      295deg,
+      rgba(255, 255, 255, 0.03) 0,
+      rgba(255, 255, 255, 0.03) 1px,
+      transparent 1px,
+      transparent 18px
+    );
+  opacity: 0.25;
 }
 html {
   scroll-behavior: smooth;
@@ -54,15 +81,17 @@ body ::-webkit-scrollbar-thumb {
 }
 
 .screen-sub-heading {
-  letter-spacing: 3px;
+  letter-spacing: 4px;
   margin: 8px 0 10px;
   font-size: 12px;
-  color: var(--black);
+  color: #4b516f;
+  text-transform: uppercase;
 }
 
 .screen-heading {
-  font-size: 32px;
-  color: #1f2235;
+  font-size: 36px;
+  color: #171a2b;
+  letter-spacing: 0.4px;
   font-family: var(--font-poppins-bold), sans-serif;
 }
 
@@ -77,7 +106,7 @@ body ::-webkit-scrollbar-thumb {
 .seperator-line {
   width: 100%;
   height: 2px;
-  background-color: #1f221f;
+  background-color: rgba(26, 30, 54, 0.55);
 }
 
 .seperator-blob {
@@ -91,7 +120,7 @@ body ::-webkit-scrollbar-thumb {
 .seperator-blob div {
   width: 35px;
   border-radius: 10px;
-  background-color: var(--dark-orange);
+  background: linear-gradient(120deg, #ff6a4f, #ff4b2f);
 }
 
 @keyframes fadeInAnimation {


### PR DESCRIPTION
## Summary
- refresh the global visual system with atmospheric gradients, subtle texture layers, and sharper section headings
- modernize hero/navigation/surface treatments (glass nav shell, refined CTA styles, elevated content cards)
- preserve section order and primary user flows while delivering a clear Phase 2 visual step beyond parity mode

## Validation
- `npm run lint`
- `npm run build`
- `npm run typecheck`
- manual smoke on locale routes (`/en`, `/es`, `/en/projects`)